### PR TITLE
[WIP] Fix compilation on mono

### DIFF
--- a/Source/Serilog.Exceptions.Test/ExceptionDestructurerTest.cs
+++ b/Source/Serilog.Exceptions.Test/ExceptionDestructurerTest.cs
@@ -1,7 +1,7 @@
 ﻿namespace Serilog.Exceptions.Test
 {
     using System;
-    using Serilog.Exceptions.Destructurers;
+    using Destructurers;
     using Xunit;
 
     public class ExceptionDestructurerTest
@@ -23,6 +23,7 @@
                 Assert.Contains(targetTypes, t => t.FullName == "System.Management.Instrumentation.InstanceNotFoundException");
                 Assert.Contains(targetTypes, t => t.FullName == "System.Management.Instrumentation.InstrumentationBaseException");
                 Assert.Contains(targetTypes, t => t.FullName == "System.Management.Instrumentation.InstrumentationException");
+                Assert.Contains(targetTypes, t => t.FullName == "System.Diagnostics.Tracing.EventSourceException");
             }
             else
             {
@@ -34,6 +35,7 @@
                 Assert.DoesNotContain(targetTypes, t => t.FullName == "System.Management.Instrumentation.InstanceNotFoundException");
                 Assert.DoesNotContain(targetTypes, t => t.FullName == "System.Management.Instrumentation.InstrumentationBaseException");
                 Assert.DoesNotContain(targetTypes, t => t.FullName == "System.Management.Instrumentation.InstrumentationException");
+                Assert.DoesNotContain(targetTypes, t => t.FullName == "System.Diagnostics.Tracing.EventSourceException");
             }
         }
     }

--- a/Source/Serilog.Exceptions.Test/SqlExceptionDestructurerTest.cs
+++ b/Source/Serilog.Exceptions.Test/SqlExceptionDestructurerTest.cs
@@ -1,0 +1,40 @@
+﻿namespace Serilog.Exceptions.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data.SqlClient;
+    using System.Reflection;
+    using Destructurers;
+    using Xunit;
+
+    public class SqlExceptionDestructurerTest
+    {
+        [Fact]
+        public void Destructure_ClientConnectionIdAvailable()
+        {
+            var data = new Dictionary<string, object>();
+            var clientConnectionId = Guid.NewGuid();
+
+            var sqlErrorCtor = typeof(SqlError).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { typeof(int), typeof(byte), typeof(byte), typeof(string), typeof(string), typeof(string), typeof(int) }, null);
+            var sqlError = sqlErrorCtor.Invoke(new object[] { 42, (byte)0, (byte)0, "local-server", "connection not responding", "GetSum41", 65 });
+
+            var sqlErrorCollectionCtor = typeof(SqlErrorCollection).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[0], null);
+            var sqlErrorCollection = sqlErrorCollectionCtor.Invoke(null);
+            var sqlErrorCollectionAdd = typeof(SqlErrorCollection).GetMethod("Add", BindingFlags.NonPublic | BindingFlags.Instance);
+            sqlErrorCollectionAdd.Invoke(sqlErrorCollection, new[] { sqlError });
+
+            var sqlExCtor = typeof(SqlException).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { typeof(string), typeof(SqlErrorCollection), typeof(Exception), typeof(Guid) }, null);
+            var exception = (SqlException)sqlExCtor.Invoke(new object[] { "Sql exception testing", sqlErrorCollection, null, clientConnectionId });
+
+            var sqlExDestructurer = new SqlExceptionDestructurer();
+
+            sqlExDestructurer.Destructure(exception, data, null);
+
+            Assert.NotNull(data);
+            if (data.ContainsKey("ClientConnectionId"))
+            {
+                Assert.Equal(clientConnectionId, data["ClientConnectionId"]);
+            }
+        }
+    }
+}

--- a/Source/Serilog.Exceptions/Destructurers/ExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ExceptionDestructurer.cs
@@ -63,7 +63,6 @@
                         typeof(System.Data.VersionNotFoundException),
 #endif
                         typeof(System.DataMisalignedException),
-                        typeof(System.Diagnostics.Tracing.EventSourceException),
                         typeof(System.DivideByZeroException),
                         typeof(System.DllNotFoundException),
 #if NET45
@@ -245,7 +244,8 @@
                 "System.Diagnostics.Eventing.Reader.EventLogReadingException, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                 "System.Management.Instrumentation.InstanceNotFoundException, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                 "System.Management.Instrumentation.InstrumentationBaseException, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
-                "System.Management.Instrumentation.InstrumentationException, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                "System.Management.Instrumentation.InstrumentationException, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "System.Diagnostics.Tracing.EventSourceException, mscorlib, Version=4.0.0.0, PublicKeyToken=b77a5c561934e089"
             };
         }
     }

--- a/Source/Serilog.Exceptions/Destructurers/SqlExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/SqlExceptionDestructurer.cs
@@ -7,6 +7,15 @@
 
     public class SqlExceptionDestructurer : ExceptionDestructurer
     {
+#if NET45
+        private readonly bool clientConnectionIdIsAvailable;
+
+        public SqlExceptionDestructurer()
+        {
+            this.clientConnectionIdIsAvailable = typeof(SqlException).GetProperty("ClientConnectionId") != null;
+        }
+#endif
+
         public override Type[] TargetTypes
         {
             get { return new Type[] { typeof(SqlException) }; }
@@ -20,8 +29,14 @@
             base.Destructure(exception, data, destructureException);
 
             var sqlException = (SqlException)exception;
-
-            data.Add(nameof(SqlException.ClientConnectionId), sqlException.ClientConnectionId);
+#if NET45
+            if (this.clientConnectionIdIsAvailable)
+            {
+#endif
+                data.Add(nameof(SqlException.ClientConnectionId), sqlException.ClientConnectionId);
+#if NET45
+            }
+#endif
             data.Add(nameof(SqlException.Class), sqlException.Class);
             data.Add(nameof(SqlException.LineNumber), sqlException.LineNumber);
             data.Add(nameof(SqlException.Number), sqlException.Number);


### PR DESCRIPTION
Fix #2 (for good I hope).

Add `EventSourceException` to types not handled by Mono.
And check if `SqlException.ClientConnectionId` is available in .net 4.5.