### PR TITLE
Detect cyclic loops and add $ref and $id properties

### DIFF
--- a/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
@@ -20,13 +20,13 @@
             IDictionary<string, object> data,
             Func<Exception, IDictionary<string, object>> destructureException)
         {
-            foreach (var p in this.DestructureObject(exception, exception.GetType(), 0))
+            foreach (var p in this.DestructureObject(exception, exception.GetType(), 0, new Dictionary<object, IDictionary<string, object>>()))
             {
                 data.Add(p.Key, p.Value);
             }
         }
 
-        private object DestructureValue(object value, int level)
+        private object DestructureValue(object value, int level, IDictionary<object, IDictionary<string, object>> destructuredObjects)
         {
             if (value == null)
             {
@@ -56,28 +56,48 @@
                 return ((IDictionary)value)
                     .Cast<DictionaryEntry>()
                     .Where(e => e.Key is string)
-                    .ToDictionary(e => (string)e.Key, e => this.DestructureValue(e.Value, level + 1));
+                    .ToDictionary(e => (string)e.Key, e => this.DestructureValue(e.Value, level + 1, destructuredObjects));
             }
 
             if (typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(valueTypeInfo))
             {
                 return ((IEnumerable)value)
                     .Cast<object>()
-                    .Select(o => this.DestructureValue(o, level + 1))
+                    .Select(o => this.DestructureValue(o, level + 1, destructuredObjects))
                     .ToList();
             }
 
-            return this.DestructureObject(value, valueType, level);
+            return this.DestructureObject(value, valueType, level, destructuredObjects);
         }
 
-        private IDictionary<string, object> DestructureObject(object value, Type valueType, int level)
+        private IDictionary<string, object> DestructureObject(object value, Type valueType, int level, IDictionary<object, IDictionary<string, object>> destructuredObjects)
         {
-            var values = valueType
+            if (destructuredObjects.ContainsKey(value))
+            {
+                var id = destructuredObjects.Keys
+                    .Where(v => v == value)
+                    .Select((v, i) => i)
+                    .Single() + 1;
+
+                destructuredObjects[value].Add("$id", id.ToString());
+
+                return new Dictionary<string, object>
+                {
+                    { "$ref", id.ToString() }
+                };
+            }
+
+            var values = new Dictionary<string, object>();
+            destructuredObjects.Add(value, values);
+
+            var properties = valueType
                 .GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                .Where(x => x.CanRead)
-                .ToDictionary(
-                    x => x.Name,
-                    x => this.DestructureValue(x.GetValue(value), level + 1));
+                .Where(x => x.CanRead);
+
+            foreach (var property in properties)
+            {
+                values.Add(property.Name, this.DestructureValue(property.GetValue(value), level + 1, destructuredObjects));
+            }
 
             values.Add("Type", valueType);
 

--- a/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
@@ -75,11 +75,11 @@
             if (destructuredObjects.ContainsKey(value))
             {
                 var id = destructuredObjects.Keys
-                    .Where(v => v == value)
-                    .Select((v, i) => i)
-                    .Single() + 1;
+                    .Select((v, i) => new { Value = v, Id = i + 1 })
+                    .First(v => v.Value == value)
+                    .Id;
 
-                destructuredObjects[value].Add("$id", id.ToString());
+                destructuredObjects[value]["$id"] = id.ToString();
 
                 return new Dictionary<string, object>
                 {

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ExceptionDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ExceptionDestructurerTest.cs
@@ -137,8 +137,7 @@
             var myObject = (Dictionary<string, object>)result["MyObject"];
 
             Assert.Equal("bar", myObject["Foo"]);
-            Assert.Equal("1", myObject["$id"]);
-            Assert.Equal("1", ((Dictionary<string, object>)myObject["Reference"])["$ref"]);
+            Assert.Equal(myObject["$id"], ((Dictionary<string, object>)myObject["Reference"])["$ref"]);
         }
     }
 }

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ExceptionDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ExceptionDestructurerTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace Serilog.Exceptions.Test.Destructurers
 {
     using System;
+    using System.Collections.Generic;
     using Newtonsoft.Json.Linq;
     using Serilog.Exceptions.Destructurers;
     using Xunit;
@@ -104,6 +105,40 @@
         {
             var applicationException = new ArgumentException();
             Test_LoggedExceptionContainsProperty(applicationException, "Type", "System.ArgumentException");
+        }
+
+        public class MyObject
+        {
+            public string Foo { get; set; }
+
+            public MyObject Reference { get; set; }
+        }
+
+        public class CyclicException : Exception
+        {
+            public MyObject MyObject { get; set; }
+        }
+
+        [Fact]
+        public void When_object_contains_cyclic_references_then_no_stackoverflow_exception_is_thrown()
+        {
+            /// Arrange
+            var exception = new CyclicException();
+            exception.MyObject = new MyObject();
+            exception.MyObject.Foo = "bar";
+            exception.MyObject.Reference = exception.MyObject;
+
+            /// Act
+            var result = new Dictionary<string, object>();
+            var destructurer = new ReflectionBasedDestructurer();
+            destructurer.Destructure(exception, result, null);
+
+            ///// Assert
+            var myObject = (Dictionary<string, object>)result["MyObject"];
+
+            Assert.Equal("bar", myObject["Foo"]);
+            Assert.Equal("1", myObject["$id"]);
+            Assert.Equal("1", ((Dictionary<string, object>)myObject["Reference"])["$ref"]);
         }
     }
 }


### PR DESCRIPTION
Detects cyclic loops and adds a $ref referencing the $id of the already generated dictionary/value (like JSON.NET handles references). 