### PR TITLE
Additional exception handler in ReflectionBasedDestructurer on invoki…

### DIFF
--- a/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
@@ -108,6 +108,9 @@
                         values.Add(property.Name, $"threw {innerException.GetType().FullName}: {innerException.Message}");
                     }
                 }
+                catch (Exception exc) {
+                    values.Add(property.Name, $"$$threw {exc.GetType().FullName}: {exc.Message}");
+                }
             }
 
             values.Add("Type", valueType);

--- a/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
@@ -108,7 +108,8 @@
                         values.Add(property.Name, $"threw {innerException.GetType().FullName}: {innerException.Message}");
                     }
                 }
-                catch (Exception exc) {
+                catch (Exception exc)
+                {
                     values.Add(property.Name, $"$$threw {exc.GetType().FullName}: {exc.Message}");
                 }
             }


### PR DESCRIPTION
…ng property getting of destructured object

Under .Net 4.6.2 when the object being destructed threw an exception from a property getter then the destructuring failed and no details were included in the log. The additional catch of any Exception solves this.