### PR TITLE
Fix reflection based destructuring of cyclic enumerables and dictionaries

### DIFF
--- a/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
@@ -60,6 +60,16 @@
 
             if (typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(valueTypeInfo))
             {
+                if (destructuredObjects.ContainsKey(value))
+                {
+                    return new Dictionary<string, object>
+                    {
+                        { "$ref", "cyclic ref" }
+                    };
+                }
+
+                destructuredObjects.Add(value, new Dictionary<string, object>());
+
                 return ((IEnumerable)value)
                     .Cast<object>()
                     .Select(o => this.DestructureValue(o, level + 1, destructuredObjects))

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ExceptionDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ExceptionDestructurerTest.cs
@@ -180,13 +180,14 @@ namespace Serilog.Exceptions.Test.Destructurers
             // Assert
             var myObject = (Dictionary<string, object>)result["MyObjectDict"];
 
-            // exception.MyObjectDict is still regular dictionary
+            // exception.MyObjectDict["Reference"] is still regular dictionary
             var firstLevelDict = Assert.IsType<Dictionary<string, object>>(myObject["Reference"]);
-
-            var secondLevelDict = Assert.IsType<Dictionary<string, object>>(firstLevelDict["x"]);
-
-            var refId = Assert.IsType<string>(secondLevelDict["$ref"]);
             var id = firstLevelDict["$id"];
+            Assert.Equal("1", id);
+
+            // exception.MyObjectDict["Reference"]["x"] we notice that we are destructuring same dictionary
+            var secondLevelDict = Assert.IsType<Dictionary<string, object>>(firstLevelDict["x"]);
+            var refId = Assert.IsType<string>(secondLevelDict["$ref"]);
             Assert.Equal(id, refId);
         }
 


### PR DESCRIPTION
Existing mechanism for breaking circular references did not take into account that 
dictionaries and enumerables can also be part of circular object graph. This change
treats enumerables and dictionaries similarly to regular objects: once they are 
destructured, they are remembered.

For enumerables the solution is limited. Because they lack properties (enumerables
are serialized directly as lists) there is no way of adding "$id" property. I decided
to keep it simple and just leave "circular ref" marker, without getting into details.

Additionally, fix was made for "reference" id's generation which was inconsistent 
and could lead to "hanging" $refs.

I added straithforward tests with scenarios that failed with previous implementation.