### PR TITLE
Fix adding exception type description if "Type" property is present

### DIFF
--- a/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
@@ -183,9 +183,29 @@ namespace Serilog.Exceptions.Destructurers
                 }
             }
 
-            values.Add("Type", valueType);
+            this.AppendTypeIfPossible(values, valueType);
 
             return values;
+        }
+
+        private void AppendTypeIfPossible(Dictionary<string, object> values, Type valueType)
+        {
+            if (values.ContainsKey("Type"))
+            {
+                if (!values.ContainsKey("$Type"))
+                {
+                    values.Add("$Type", valueType);
+                }
+                else
+                {
+                    // If both "Type" and "$Type" are present
+                    // we just give up appending exception type
+                }
+            }
+            else
+            {
+                values.Add("Type", valueType);
+            }
         }
     }
 }

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ExceptionDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ExceptionDestructurerTest.cs
@@ -109,6 +109,13 @@ namespace Serilog.Exceptions.Test.Destructurers
         }
 
         [Fact]
+        public void ExceptionWithTypeProperty_StillContainsType_JustWithDollarAsPrefixInLabel()
+        {
+            var exceptionWithTypeProperty = new ExceptionWithTypeProperty() { Type = 13 };
+            Test_LoggedExceptionContainsProperty(exceptionWithTypeProperty, "$Type", "Serilog.Exceptions.Test.Destructurers.ExceptionDestructurerTest+ExceptionWithTypeProperty");
+        }
+
+        [Fact]
         public void When_object_contains_cyclic_references_then_no_stackoverflow_exception_is_thrown()
         {
             // Arrange
@@ -247,6 +254,11 @@ namespace Serilog.Exceptions.Test.Destructurers
             public string Foo { get; set; }
 
             public Dictionary<string, object> Reference { get; set; }
+        }
+
+        public class ExceptionWithTypeProperty : Exception
+        {
+            public int Type { get; set; }
         }
     }
 }


### PR DESCRIPTION
Destructurer failed in case of exception with property with name "Type".
By failure, I mean throwing "Key already present in dictionary" exception and
not logging exception data at all.

This change introduces fallback to "$Type" property and silent skip of 
appending exception type if "$Type" is taken as well.