### PR TITLE
Added ability to ignore properties in logs

### DIFF
--- a/Source/Serilog.Exceptions/Destructurers/AggregateExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/AggregateExceptionDestructurer.cs
@@ -1,4 +1,4 @@
-﻿namespace Serilog.Exceptions.Destructurers
+namespace Serilog.Exceptions.Destructurers
 {
     using System;
     using System.Collections.Generic;
@@ -6,6 +6,11 @@
 
     public class AggregateExceptionDestructurer : ExceptionDestructurer
     {
+        public AggregateExceptionDestructurer(List<string> ignoredProperties)
+            : base(ignoredProperties)
+        {
+        }
+
         public override Type[] TargetTypes
         {
             get { return new Type[] { typeof(AggregateException) }; }
@@ -20,9 +25,10 @@
 
             var aggregateException = (AggregateException)exception;
 
-            data.Add(
+            data.AddIfNotIgnored(
                 nameof(AggregateException.InnerExceptions),
-                aggregateException.InnerExceptions.Select(destructureException).ToList());
+                aggregateException.InnerExceptions.Select(destructureException).ToList(),
+                this.IgnoredProperties);
         }
     }
 }

--- a/Source/Serilog.Exceptions/Destructurers/ArgumentExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ArgumentExceptionDestructurer.cs
@@ -1,10 +1,15 @@
-﻿namespace Serilog.Exceptions.Destructurers
+namespace Serilog.Exceptions.Destructurers
 {
     using System;
     using System.Collections.Generic;
 
     public class ArgumentExceptionDestructurer : ExceptionDestructurer
     {
+        public ArgumentExceptionDestructurer(List<string> ignoredProperties)
+            : base(ignoredProperties)
+        {
+        }
+
         public override Type[] TargetTypes
         {
             get
@@ -26,7 +31,7 @@
 
             var argumentException = (ArgumentException)exception;
 
-            data.Add(nameof(ArgumentException.ParamName), argumentException.ParamName);
+            data.AddIfNotIgnored(nameof(ArgumentException.ParamName), argumentException.ParamName, this.IgnoredProperties);
         }
     }
 }

--- a/Source/Serilog.Exceptions/Destructurers/ArgumentOutOfRangeExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ArgumentOutOfRangeExceptionDestructurer.cs
@@ -1,10 +1,15 @@
-﻿namespace Serilog.Exceptions.Destructurers
+namespace Serilog.Exceptions.Destructurers
 {
     using System;
     using System.Collections.Generic;
 
     public class ArgumentOutOfRangeExceptionDestructurer : ArgumentExceptionDestructurer
     {
+        public ArgumentOutOfRangeExceptionDestructurer(List<string> ignoredProperties)
+            : base(ignoredProperties)
+        {
+        }
+
         public override Type[] TargetTypes
         {
             get
@@ -25,7 +30,7 @@
 
             var argumentException = (ArgumentOutOfRangeException)exception;
 
-            data.Add(nameof(ArgumentOutOfRangeException.ActualValue), argumentException.ActualValue);
+            data.AddIfNotIgnored(nameof(ArgumentOutOfRangeException.ActualValue), argumentException.ActualValue, this.IgnoredProperties);
         }
     }
 }

--- a/Source/Serilog.Exceptions/Destructurers/ExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ExceptionDestructurer.cs
@@ -1,4 +1,4 @@
-﻿namespace Serilog.Exceptions.Destructurers
+namespace Serilog.Exceptions.Destructurers
 {
     using System;
     using System.Collections;
@@ -7,6 +7,11 @@
 
     public class ExceptionDestructurer : IExceptionDestructurer
     {
+        public ExceptionDestructurer(List<string> ignoredProperties)
+        {
+            this.IgnoredProperties = ignoredProperties;
+        }
+
         public virtual Type[] TargetTypes
         {
             get
@@ -186,42 +191,44 @@
             }
         }
 
+        public List<string> IgnoredProperties { get; set; }
+
         public virtual void Destructure(
             Exception exception,
             IDictionary<string, object> data,
             Func<Exception, IDictionary<string, object>> innerDestructure)
         {
-            data.Add("Type", exception.GetType().FullName);
+            data.AddIfNotIgnored("Type", exception.GetType().FullName, this.IgnoredProperties);
 
             if (exception.Data.Count != 0)
             {
-                data.Add(nameof(Exception.Data), exception.Data.ToStringObjectDictionary());
+                data.AddIfNotIgnored(nameof(Exception.Data), exception.Data.ToStringObjectDictionary(this.IgnoredProperties), this.IgnoredProperties);
             }
 
             if (!string.IsNullOrEmpty(exception.HelpLink))
             {
-                data.Add(nameof(Exception.HelpLink), exception.HelpLink);
+                data.AddIfNotIgnored(nameof(Exception.HelpLink), exception.HelpLink, this.IgnoredProperties);
             }
 
             if (exception.HResult != 0)
             {
-                data.Add(nameof(Exception.HResult), exception.HResult);
+                data.AddIfNotIgnored(nameof(Exception.HResult), exception.HResult, this.IgnoredProperties);
             }
 
-            data.Add(nameof(Exception.Message), exception.Message);
-            data.Add(nameof(Exception.Source), exception.Source);
-            data.Add(nameof(Exception.StackTrace), exception.StackTrace);
+            data.AddIfNotIgnored(nameof(Exception.Message), exception.Message, this.IgnoredProperties);
+            data.AddIfNotIgnored(nameof(Exception.Source), exception.Source, this.IgnoredProperties);
+            data.AddIfNotIgnored(nameof(Exception.StackTrace), exception.StackTrace, this.IgnoredProperties);
 
 #if NET45
             if (exception.TargetSite != null)
             {
-                data.Add(nameof(Exception.TargetSite), exception.TargetSite.ToString());
+                data.AddIfNotIgnored(nameof(Exception.TargetSite), exception.TargetSite.ToString(), this.IgnoredProperties);
             }
 #endif
 
             if (exception.InnerException != null)
             {
-                data.Add(nameof(Exception.InnerException), innerDestructure(exception.InnerException));
+                data.AddIfNotIgnored(nameof(Exception.InnerException), innerDestructure(exception.InnerException), this.IgnoredProperties);
             }
         }
 

--- a/Source/Serilog.Exceptions/Destructurers/ExceptionEnricher.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ExceptionEnricher.cs
@@ -1,4 +1,4 @@
-﻿namespace Serilog.Exceptions.Destructurers
+namespace Serilog.Exceptions.Destructurers
 {
     using System;
     using System.Collections.Generic;
@@ -11,23 +11,18 @@
     /// </summary>
     public sealed class ExceptionEnricher : ILogEventEnricher
     {
-        public static readonly IExceptionDestructurer[] DefaultDestructurers =
-        {
-            new ExceptionDestructurer(),
-            new ArgumentExceptionDestructurer(),
-            new ArgumentOutOfRangeExceptionDestructurer(),
-            new AggregateExceptionDestructurer(),
-            new ReflectionTypeLoadExceptionDestructurer(),
-            new SqlExceptionDestructurer()
-        };
-
-        public static readonly IExceptionDestructurer ReflectionBasedDestructurer = new ReflectionBasedDestructurer();
-
+        private static IExceptionDestructurer reflectionBasedDestructurer;
         private readonly Dictionary<Type, IExceptionDestructurer> destructurers;
 
         public ExceptionEnricher()
-            : this(DefaultDestructurers)
+            : this(GetDefaultDestructurers(new List<string>()))
         {
+        }
+
+        public ExceptionEnricher(List<string> ignoredProperties)
+            : this(GetDefaultDestructurers(ignoredProperties))
+        {
+            reflectionBasedDestructurer = new ReflectionBasedDestructurer(ignoredProperties);
         }
 
         public ExceptionEnricher(params IExceptionDestructurer[] destructurers)
@@ -58,6 +53,20 @@
             }
         }
 
+        private static IExceptionDestructurer[] GetDefaultDestructurers(List<string> ignoredProperties)
+        {
+            var list = new List<IExceptionDestructurer>
+            {
+                new ExceptionDestructurer(ignoredProperties),
+                new ArgumentExceptionDestructurer(ignoredProperties),
+                new ArgumentOutOfRangeExceptionDestructurer(ignoredProperties),
+                new AggregateExceptionDestructurer(ignoredProperties),
+                new ReflectionTypeLoadExceptionDestructurer(ignoredProperties),
+                new SqlExceptionDestructurer(ignoredProperties)
+            };
+            return list.ToArray();
+        }
+
         private Dictionary<string, object> DestructureException(Exception exception)
         {
             var data = new Dictionary<string, object>();
@@ -67,11 +76,11 @@
             if (this.destructurers.ContainsKey(exceptionType))
             {
                 var destructurer = this.destructurers[exceptionType];
-                destructurer.Destructure(exception, data, this.DestructureException);
+                destructurer.Destructure(exception, data,  this.DestructureException);
             }
             else
             {
-                ReflectionBasedDestructurer.Destructure(exception, data, this.DestructureException);
+                reflectionBasedDestructurer.Destructure(exception, data, this.DestructureException);
             }
 
             return data;

--- a/Source/Serilog.Exceptions/Destructurers/IExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/IExceptionDestructurer.cs
@@ -1,4 +1,4 @@
-﻿namespace Serilog.Exceptions.Destructurers
+namespace Serilog.Exceptions.Destructurers
 {
     using System;
     using System.Collections.Generic;
@@ -6,6 +6,8 @@
     public interface IExceptionDestructurer
     {
         Type[] TargetTypes { get; }
+
+        List<string> IgnoredProperties { get; set; }
 
         void Destructure(
             Exception exception,

--- a/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
@@ -13,6 +13,13 @@ namespace Serilog.Exceptions.Destructurers
         private const string CyclicReferenceMessage = "Cyclic reference";
         private const int MaxRecursiveLevel = 10;
 
+        public ReflectionBasedDestructurer(List<string> ignoredProperties)
+        {
+            this.IgnoredProperties = ignoredProperties;
+        }
+
+        public List<string> IgnoredProperties { get; set; }
+
         public Type[] TargetTypes => new Type[] { typeof(Exception) };
 
         public void Destructure(
@@ -28,7 +35,7 @@ namespace Serilog.Exceptions.Destructurers
                 new Dictionary<object, IDictionary<string, object>>(),
                 ref nextCyclicRefId))
             {
-                data.Add(p.Key, p.Value);
+                data.AddIfNotIgnored(p.Key, p.Value, this.IgnoredProperties);
             }
         }
 
@@ -122,13 +129,13 @@ namespace Serilog.Exceptions.Destructurers
                 };
             }
 
-            var destructuredDictionary = ((IDictionary)value).ToStringObjectDictionary();
+            var destructuredDictionary = ((IDictionary)value).ToStringObjectDictionary(this.IgnoredProperties);
             destructuredObjects.Add(value, destructuredDictionary);
 
             foreach (var kvp in destructuredDictionary.ToDictionary(k => k.Key, v => v.Value))
             {
                 destructuredDictionary[kvp.Key] =
-                    this.DestructureValue(kvp.Value, level + 1, destructuredObjects, ref nextCyclicRefId);
+                        this.DestructureValue(kvp.Value, level + 1, destructuredObjects, ref nextCyclicRefId);
             }
 
             return destructuredDictionary;
@@ -163,28 +170,30 @@ namespace Serilog.Exceptions.Destructurers
             {
                 try
                 {
-                    values.Add(property.Name, this.DestructureValue(
+                    values.AddIfNotIgnored(
+                        property.Name,
+                        this.DestructureValue(
                         property.GetValue(value),
                         level + 1,
                         destructuredObjects,
-                        ref nextCyclicRefId));
+                        ref nextCyclicRefId),
+                        this.IgnoredProperties);
                 }
                 catch (TargetInvocationException targetInvocationException)
                 {
                     var innerException = targetInvocationException.InnerException;
                     if (innerException != null)
                     {
-                        values.Add(property.Name, $"threw {innerException.GetType().FullName}: {innerException.Message}");
+                        values.AddIfNotIgnored(property.Name, $"threw {innerException.GetType().FullName}: {innerException.Message}", this.IgnoredProperties);
                     }
                 }
                 catch (Exception exception)
                 {
-                    values.Add(property.Name, $"threw {exception.GetType().FullName}: {exception.Message}");
+                    values.AddIfNotIgnored(property.Name, $"threw {exception.GetType().FullName}: {exception.Message}", this.IgnoredProperties);
                 }
             }
 
             this.AppendTypeIfPossible(values, valueType);
-
             return values;
         }
 
@@ -194,7 +203,7 @@ namespace Serilog.Exceptions.Destructurers
             {
                 if (!values.ContainsKey("$Type"))
                 {
-                    values.Add("$Type", valueType);
+                    values.AddIfNotIgnored("$Type", valueType, this.IgnoredProperties);
                 }
                 else
                 {
@@ -204,7 +213,7 @@ namespace Serilog.Exceptions.Destructurers
             }
             else
             {
-                values.Add("Type", valueType);
+                values.AddIfNotIgnored("Type", valueType, this.IgnoredProperties);
             }
         }
     }

--- a/Source/Serilog.Exceptions/Destructurers/ReflectionTypeLoadExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ReflectionTypeLoadExceptionDestructurer.cs
@@ -1,4 +1,4 @@
-﻿namespace Serilog.Exceptions.Destructurers
+namespace Serilog.Exceptions.Destructurers
 {
     using System;
     using System.Collections.Generic;
@@ -7,6 +7,11 @@
 
     public class ReflectionTypeLoadExceptionDestructurer : ExceptionDestructurer
     {
+        public ReflectionTypeLoadExceptionDestructurer(List<string> ignoredProperties)
+            : base(ignoredProperties)
+        {
+        }
+
         public override Type[] TargetTypes
         {
             get { return new Type[] { typeof(ReflectionTypeLoadException) }; }
@@ -23,9 +28,10 @@
 
             if (reflectionTypeLoadException.LoaderExceptions != null)
             {
-                data.Add(
+                data.AddIfNotIgnored(
                     nameof(ReflectionTypeLoadException.LoaderExceptions),
-                    reflectionTypeLoadException.LoaderExceptions.Select(destructureException).ToList());
+                    reflectionTypeLoadException.LoaderExceptions.Select(destructureException).ToList(),
+                    this.IgnoredProperties);
             }
         }
     }

--- a/Source/Serilog.Exceptions/Destructurers/SqlExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/SqlExceptionDestructurer.cs
@@ -1,4 +1,4 @@
-﻿namespace Serilog.Exceptions.Destructurers
+namespace Serilog.Exceptions.Destructurers
 {
     using System;
     using System.Collections.Generic;
@@ -7,6 +7,11 @@
 
     public class SqlExceptionDestructurer : ExceptionDestructurer
     {
+        public SqlExceptionDestructurer(List<string> ignoredProperties)
+            : base(ignoredProperties)
+        {
+        }
+
         public override Type[] TargetTypes
         {
             get { return new Type[] { typeof(SqlException) }; }
@@ -23,12 +28,12 @@
 
             // Don't log ClientConnectionId because it's not supported on Mono.
             // data.Add(nameof(SqlException.ClientConnectionId), sqlException.ClientConnectionId);
-            data.Add(nameof(SqlException.Class), sqlException.Class);
-            data.Add(nameof(SqlException.LineNumber), sqlException.LineNumber);
-            data.Add(nameof(SqlException.Number), sqlException.Number);
-            data.Add(nameof(SqlException.Server), sqlException.Server);
-            data.Add(nameof(SqlException.State), sqlException.State);
-            data.Add(nameof(SqlException.Errors), sqlException.Errors.Cast<SqlError>().ToList());
+            data.AddIfNotIgnored(nameof(SqlException.Class), sqlException.Class, this.IgnoredProperties);
+            data.AddIfNotIgnored(nameof(SqlException.LineNumber), sqlException.LineNumber, this.IgnoredProperties);
+            data.AddIfNotIgnored(nameof(SqlException.Number), sqlException.Number, this.IgnoredProperties);
+            data.AddIfNotIgnored(nameof(SqlException.Server), sqlException.Server, this.IgnoredProperties);
+            data.AddIfNotIgnored(nameof(SqlException.State), sqlException.State, this.IgnoredProperties);
+            data.AddIfNotIgnored(nameof(SqlException.Errors), sqlException.Errors.Cast<SqlError>().ToList(), this.IgnoredProperties);
         }
     }
 }

--- a/Source/Serilog.Exceptions/DictionaryExtensions.cs
+++ b/Source/Serilog.Exceptions/DictionaryExtensions.cs
@@ -1,22 +1,47 @@
-﻿namespace Serilog.Exceptions
+namespace Serilog.Exceptions
 {
+    using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.Linq;
 
     internal static class DictionaryExtensions
     {
-        public static Dictionary<string, object> ToStringObjectDictionary(this IDictionary dictionary)
+        public static Dictionary<string, object> ToStringObjectDictionary(this IDictionary dictionary, List<string> ignoredProperties)
         {
             var result = new Dictionary<string, object>();
-
             foreach (var key in dictionary.Keys)
             {
                 var value = dictionary[key];
+                if (ignoredProperties.Contains(key.ToString()))
+                {
+                    continue;
+                }
 
-                result.Add(key.ToString(), value);
+                if (value is KeyValuePair<string, string> parsedKeyValuePair)
+                {
+                    if (ignoredProperties.Contains(parsedKeyValuePair.Key))
+                    {
+                        continue;
+                    }
+
+                    result.AddIfNotIgnored(key.ToString(), value, ignoredProperties);
+                }
+                else
+                {
+                    result.AddIfNotIgnored(key.ToString(), value, ignoredProperties);
+                }
             }
 
             return result;
+        }
+
+        public static void AddIfNotIgnored(this IDictionary<string, object> dictionary, string key, object value, List<string> ignoredProperties)
+        {
+            if (!ignoredProperties.Contains(key))
+            {
+                dictionary.Add(key, value);
+            }
         }
     }
 }

--- a/Source/Serilog.Exceptions/DictionaryExtensions.cs
+++ b/Source/Serilog.Exceptions/DictionaryExtensions.cs
@@ -13,19 +13,9 @@ namespace Serilog.Exceptions
             foreach (var key in dictionary.Keys)
             {
                 var value = dictionary[key];
-                if (ignoredProperties.Contains(key.ToString()))
-                {
-                    continue;
-                }
-
                 if (value is KeyValuePair<string, string> parsedKeyValuePair)
                 {
-                    if (ignoredProperties.Contains(parsedKeyValuePair.Key))
-                    {
-                        continue;
-                    }
-
-                    result.AddIfNotIgnored(key.ToString(), value, ignoredProperties);
+                    result.AddIfNotIgnored(parsedKeyValuePair.Key, value, ignoredProperties);
                 }
                 else
                 {

--- a/Source/Serilog.Exceptions/LoggerEnrichmentConfigurationExtensions.cs
+++ b/Source/Serilog.Exceptions/LoggerEnrichmentConfigurationExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Serilog.Exceptions
+namespace Serilog.Exceptions
 {
     using System;
     using System.Collections.Generic;
@@ -10,7 +10,14 @@
         public static Serilog.LoggerConfiguration WithExceptionDetails(
             this LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
         {
-            return loggerEnrichmentConfiguration.With(new ExceptionEnricher());
+            return loggerEnrichmentConfiguration.With(new ExceptionEnricher(new List<string>()));
+        }
+
+        public static Serilog.LoggerConfiguration WithExceptionDetails(
+            this LoggerEnrichmentConfiguration loggerEnrichmentConfiguration,
+            List<string> ignoredProperties)
+        {
+            return loggerEnrichmentConfiguration.With(new ExceptionEnricher(ignoredProperties));
         }
 
         public static Serilog.LoggerConfiguration WithExceptionDetails(

--- a/Tests/Serilog.Exceptions.Test/Destructurers/LogJsonOutputUtils.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/LogJsonOutputUtils.cs
@@ -1,6 +1,7 @@
-﻿namespace Serilog.Exceptions.Test.Destructurers
+namespace Serilog.Exceptions.Test.Destructurers
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
@@ -19,7 +20,26 @@
             var jsonWriter = new StringWriter();
 
             ILogger logger = new LoggerConfiguration()
-                .Enrich.WithExceptionDetails()
+                .Enrich.WithExceptionDetails(new List<string>())
+                .WriteTo.Sink(new TestTextWriterSink(jsonWriter, new JsonFormatter()))
+                .CreateLogger();
+
+            // Act
+            logger.Error(exception, "EXCEPTION MESSAGE");
+
+            // Assert
+            var writtenJson = jsonWriter.ToString();
+            var jsonObj = JsonConvert.DeserializeObject<object>(writtenJson);
+            JObject rootObject = Assert.IsType<JObject>(jsonObj);
+            return rootObject;
+        }
+
+        public static JObject LogAndDestructureException(Exception exception, List<string> ignoredProperties)
+        {
+            var jsonWriter = new StringWriter();
+
+            ILogger logger = new LoggerConfiguration()
+                .Enrich.WithExceptionDetails(ignoredProperties)
                 .WriteTo.Sink(new TestTextWriterSink(jsonWriter, new JsonFormatter()))
                 .CreateLogger();
 

--- a/Tests/Serilog.Exceptions.Test/DictionaryExtensionsTest.cs
+++ b/Tests/Serilog.Exceptions.Test/DictionaryExtensionsTest.cs
@@ -1,4 +1,4 @@
-﻿namespace Serilog.Exceptions.Test
+namespace Serilog.Exceptions.Test
 {
     using System.Collections;
     using System.Collections.Generic;
@@ -16,7 +16,7 @@
                 { "Key", "Value" }
             };
 
-            var actual = dictionary.ToStringObjectDictionary();
+            var actual = dictionary.ToStringObjectDictionary(new List<string>());
 
             Assert.Single(actual);
             Assert.Equal("Key", actual.First().Key);
@@ -31,8 +31,23 @@
                 { "Key", "Value" }
             };
 
-            var actual = dictionary.ToStringObjectDictionary();
+            var actual = dictionary.ToStringObjectDictionary(new List<string>());
 
+            Assert.Single(actual);
+            Assert.Equal("Key", actual.First().Key);
+            Assert.Equal("Value", actual.First().Value);
+        }
+
+        [Fact]
+        public void ToStringObjectDictionary_IgnoredPropertiesAreNotAdded()
+        {
+            var dictionary = (IDictionary)new Dictionary<string, object>()
+            {
+                { "IgnoredKey", "Value" },
+                { "Key", "Value" }
+            };
+
+            var actual = dictionary.ToStringObjectDictionary(new List<string>() { "IgnoredKey" });
             Assert.Single(actual);
             Assert.Equal("Key", actual.First().Key);
             Assert.Equal("Value", actual.First().Value);


### PR DESCRIPTION
A list of property names can now be passed to the logger configuration, if a property is on the list, it will not show up in the  destructured log.