### PR TITLE
[WIP] Support `Serilog.Settings.Configuration`

### DIFF
--- a/Source/Serilog.Exceptions/LoggerEnrichmentConfigurationExtensions.cs
+++ b/Source/Serilog.Exceptions/LoggerEnrichmentConfigurationExtensions.cs
@@ -21,15 +21,18 @@ namespace Serilog.Exceptions
         /// </summary>
         /// <param name="loggerEnrichmentConfiguration">The enrichment configuration</param>
         /// <param name="customRootName">Name of the property which value will be filled with destructured exception.</param>
+        /// <param name="destructuringDepth">Maximum destructuring depth that <see cref="ExceptionEnricher"/> will reach during destructuring of unknown exception type.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         public static Serilog.LoggerConfiguration WithExceptionDetails(
             this LoggerEnrichmentConfiguration loggerEnrichmentConfiguration,
-            string customRootName = "ExceptionDetails")
+            string customRootName = "ExceptionDetail",
+            int destructuringDepth = 10)
         {
             var options = new DestructuringOptionsBuilder()
                 .WithDefaultDestructurers()
                 .WithIgnoreStackTraceAndTargetSiteExceptionFilter()
-                .WithRootName(customRootName);
+                .WithRootName(customRootName)
+                .WithDestructuringDepth(destructuringDepth);
             var logEventEnricher = new ExceptionEnricher(options);
             return loggerEnrichmentConfiguration.With(logEventEnricher);
         }

--- a/Source/Serilog.Exceptions/LoggerEnrichmentConfigurationExtensions.cs
+++ b/Source/Serilog.Exceptions/LoggerEnrichmentConfigurationExtensions.cs
@@ -20,13 +20,16 @@ namespace Serilog.Exceptions
         /// by the destructuring process because Serilog already attaches them to log event.
         /// </summary>
         /// <param name="loggerEnrichmentConfiguration">The enrichment configuration</param>
+        /// <param name="customRootName">Name of the property which value will be filled with destructured exception.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         public static Serilog.LoggerConfiguration WithExceptionDetails(
-            this LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
+            this LoggerEnrichmentConfiguration loggerEnrichmentConfiguration,
+            string customRootName = "ExceptionDetails")
         {
             var options = new DestructuringOptionsBuilder()
                 .WithDefaultDestructurers()
-                .WithIgnoreStackTraceAndTargetSiteExceptionFilter();
+                .WithIgnoreStackTraceAndTargetSiteExceptionFilter()
+                .WithRootName(customRootName);
             var logEventEnricher = new ExceptionEnricher(options);
             return loggerEnrichmentConfiguration.With(logEventEnricher);
         }

--- a/Tests/Serilog.Exceptions.Test/Configuration/SerilogSettingsConfigurationTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Configuration/SerilogSettingsConfigurationTest.cs
@@ -2,6 +2,8 @@ namespace Serilog.Exceptions.Test.Configuration
 {
     using System;
     using System.IO;
+    using System.Linq;
+    using FluentAssertions;
     using Microsoft.Extensions.Configuration;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
@@ -37,6 +39,59 @@ namespace Serilog.Exceptions.Test.Configuration
             var jsonObj = JsonConvert.DeserializeObject<object>(writtenJson);
             JObject rootObject = Assert.IsType<JObject>(jsonObj);
             LogJsonOutputUtils.ExtractExceptionDetails(rootObject, customRootName);
+        }
+
+        [Fact]
+        public void RecursiveException_DestructuringDepthIsLimitedByConfiguredDepth()
+        {
+            // Arrange
+            var exception = new RecursiveException()
+            {
+                Node = new RecursiveNode()
+                {
+                    Name = "PARENT",
+                    Child = new RecursiveNode()
+                    {
+                        Name = "CHILD 1",
+                        Child = new RecursiveNode()
+                        {
+                            Name = "CHILD 2"
+                        }
+                    }
+                }
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile("Configuration/limitDestructuringDepthTo1.json")
+                .Build();
+            var jsonWriter = new StringWriter();
+            ILogger logger = new LoggerConfiguration()
+                .ReadFrom.Configuration(configuration)
+                .WriteTo.Sink(new LogJsonOutputUtils.TestTextWriterSink(jsonWriter, new JsonFormatter()))
+                .CreateLogger();
+
+            // Act
+            logger.Error(exception, "EXCEPTION MESSAGE");
+
+            // Assert
+            // Parent is depth 1
+            // First child is depth 2
+            var writtenJson = jsonWriter.ToString();
+            var jsonObj = JsonConvert.DeserializeObject<object>(writtenJson);
+            JObject rootObject = Assert.IsType<JObject>(jsonObj);
+            JObject exceptionDetails = LogJsonOutputUtils.ExtractExceptionDetails(rootObject);
+            JObject parentNode = exceptionDetails.Properties().Should()
+                .ContainSingle(p => p.Name == nameof(RecursiveException.Node))
+                .Which.Value.Should().BeOfType<JObject>().Which;
+            var parentProperties = parentNode.Properties().ToArray();
+            parentProperties.Should().ContainSingle(p => p.Name == "Name").Which.Value.Should().BeOfType<JValue>().Which.Value.Should().Be("PARENT");
+            parentProperties.Should().NotContain(p => p.Name == "_typeTag");
+            var child = parentProperties.Should()
+                .ContainSingle(p => p.Name == "Child")
+                .Which.Value.Should().BeOfType<JObject>().Which;
+            var childProperties = child.Properties().ToArray();
+            childProperties.Should()
+                .ContainSingle(p => p.Name == "_typeTag", "typeTag indicates that object was not destructured using Serilog.Exceptions");
         }
 #endif
     }

--- a/Tests/Serilog.Exceptions.Test/Configuration/SerilogSettingsConfigurationTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Configuration/SerilogSettingsConfigurationTest.cs
@@ -1,0 +1,43 @@
+namespace Serilog.Exceptions.Test.Configuration
+{
+    using System;
+    using System.IO;
+    using Microsoft.Extensions.Configuration;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+    using Serilog.Exceptions.Core;
+    using Serilog.Exceptions.Test.Destructurers;
+    using Serilog.Formatting.Json;
+    using Xunit;
+
+    public class SerilogSettingsConfigurationTest
+    {
+#if NETCOREAPP2_0
+        [Fact]
+        public void ArgumentException_WithCustomRootName_ContainsDataInCustomRootName()
+        {
+            // Arrange
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile("Configuration/customRootName.json")
+                .Build();
+            var jsonWriter = new StringWriter();
+            ILogger logger = new LoggerConfiguration()
+                .ReadFrom.Configuration(configuration)
+                .WriteTo.Sink(new LogJsonOutputUtils.TestTextWriterSink(jsonWriter, new JsonFormatter()))
+                .CreateLogger();
+
+            var exception = new ArgumentException();
+            const string customRootName = "Ex";
+
+            // Act
+            logger.Error(exception, "EXCEPTION MESSAGE");
+
+            // Assert
+            var writtenJson = jsonWriter.ToString();
+            var jsonObj = JsonConvert.DeserializeObject<object>(writtenJson);
+            JObject rootObject = Assert.IsType<JObject>(jsonObj);
+            LogJsonOutputUtils.ExtractExceptionDetails(rootObject, customRootName);
+        }
+#endif
+    }
+}

--- a/Tests/Serilog.Exceptions.Test/Configuration/customRootName.json
+++ b/Tests/Serilog.Exceptions.Test/Configuration/customRootName.json
@@ -1,0 +1,11 @@
+{
+  "Serilog": {
+    "MinimumLevel": "Debug",
+    "Enrich": [
+      {
+        "Name": "WithExceptionDetails",
+        "Args": { "customRootName": "Ex" }
+      }
+    ]
+  }
+}

--- a/Tests/Serilog.Exceptions.Test/Configuration/limitDestructuringDepthTo1.json
+++ b/Tests/Serilog.Exceptions.Test/Configuration/limitDestructuringDepthTo1.json
@@ -1,0 +1,11 @@
+{
+  "Serilog": {
+    "MinimumLevel": "Debug",
+    "Enrich": [
+      {
+        "Name": "WithExceptionDetails",
+        "Args": { "destructuringDepth": 1 }
+      }
+    ]
+  }
+}

--- a/Tests/Serilog.Exceptions.Test/Destructurers/LogJsonOutputUtils.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/LogJsonOutputUtils.cs
@@ -1,3 +1,5 @@
+using FluentAssertions;
+
 namespace Serilog.Exceptions.Test.Destructurers
 {
     using System;
@@ -58,7 +60,11 @@ namespace Serilog.Exceptions.Test.Destructurers
             JProperty propertiesProperty = Assert.Single(jObject.Properties(), x => x.Name == "Properties");
             JObject propertiesObject = Assert.IsType<JObject>(propertiesProperty.Value);
 
-            JProperty exceptionDetailProperty = Assert.Single(propertiesObject.Properties(), x => x.Name == rootName);
+            JProperty exceptionDetailProperty = propertiesObject.Properties().Should()
+                .ContainSingle(
+                    x => x.Name == rootName,
+                    "expected {0} to be present in destructured properties",
+                    rootName).Which;
             JObject exceptionDetailValue = Assert.IsType<JObject>(exceptionDetailProperty.Value);
 
             return exceptionDetailValue;

--- a/Tests/Serilog.Exceptions.Test/Destructurers/LogJsonOutputUtils.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/LogJsonOutputUtils.cs
@@ -1,16 +1,14 @@
-using FluentAssertions;
-
 namespace Serilog.Exceptions.Test.Destructurers
 {
     using System;
     using System.IO;
+    using System.Linq;
+    using FluentAssertions;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
     using Serilog.Core;
     using Serilog.Events;
     using Serilog.Exceptions.Core;
-    using Serilog.Exceptions.Destructurers;
-    using Serilog.Exceptions.Filters;
     using Serilog.Formatting;
     using Serilog.Formatting.Json;
     using Xunit;
@@ -60,7 +58,8 @@ namespace Serilog.Exceptions.Test.Destructurers
             JProperty propertiesProperty = Assert.Single(jObject.Properties(), x => x.Name == "Properties");
             JObject propertiesObject = Assert.IsType<JObject>(propertiesProperty.Value);
 
-            JProperty exceptionDetailProperty = propertiesObject.Properties().Should()
+            JProperty[] properties = propertiesObject.Properties().ToArray();
+            JProperty exceptionDetailProperty = properties.Should()
                 .ContainSingle(
                     x => x.Name == rootName,
                     "expected {0} to be present in destructured properties",

--- a/Tests/Serilog.Exceptions.Test/Destructurers/RecursiveException.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/RecursiveException.cs
@@ -1,0 +1,18 @@
+namespace Serilog.Exceptions.Test.Destructurers
+{
+    using System;
+
+    public class RecursiveException : Exception
+    {
+        public RecursiveNode Node { get; set; }
+    }
+
+#pragma warning disable SA1402 // File may only contain a single type
+    public class RecursiveNode
+#pragma warning restore SA1402 // File may only contain a single type
+    {
+        public string Name { get; set; }
+
+        public RecursiveNode Child { get; set; }
+    }
+}

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ReflectionBasedDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ReflectionBasedDestructurerTest.cs
@@ -261,14 +261,16 @@ namespace Serilog.Exceptions.Test.Destructurers
             Test_ResultOfReflectionDestructurerShouldBeEquivalentToCustomOne(exception, new ArgumentExceptionDestructurer());
         }
 
-        // To be discussed: whether we need to keep consistent behaviour even for inner exceptions
-        //[Fact]
-        //public void WhenDestruringAggregateException_ResultShouldBeEquivalentToAggregateExceptionDestructurer()
-        //{
-        //    var argumentException = ThrowAndCatchException(() => throw new ArgumentException("MESSAGE", "paramName"));
-        //    var aggregateException = ThrowAndCatchException(() => throw new AggregateException(argumentException));
-        //    Test_ResultOfReflectionDestructurerShouldBeEquivalentToCustomOne(aggregateException, new AggregateExceptionDestructurer());
-        //}
+        /*
+         To be discussed: whether we need to keep consistent behaviour even for inner exceptions
+        [Fact]
+        public void WhenDestruringAggregateException_ResultShouldBeEquivalentToAggregateExceptionDestructurer()
+        {
+            var argumentException = ThrowAndCatchException(() => throw new ArgumentException("MESSAGE", "paramName"));
+            var aggregateException = ThrowAndCatchException(() => throw new AggregateException(argumentException));
+            Test_ResultOfReflectionDestructurerShouldBeEquivalentToCustomOne(aggregateException, new AggregateExceptionDestructurer());
+        }
+        */
 
         private static void Test_ResultOfReflectionDestructurerShouldBeEquivalentToCustomOne(
             Exception exception,
@@ -415,18 +417,6 @@ namespace Serilog.Exceptions.Test.Destructurers
             }
 
             public Uri Uri { get; }
-        }
-
-        public class RecursiveNode
-        {
-            public string Name { get; set; }
-
-            public RecursiveNode Child { get; set; }
-        }
-
-        public class RecursiveException : Exception
-        {
-            public RecursiveNode Node { get; set; }
         }
 
         [Serializable]

--- a/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
+++ b/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.0-dev-00081" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.0-beta004" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
@@ -36,6 +37,21 @@
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration">
+      <Version>2.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json">
+      <Version>2.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Configuration\customRootName.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
+++ b/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
@@ -49,6 +49,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Configuration\limitDestructuringDepthTo1.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Configuration\customRootName.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Initially `customRootName` and `destructuringDepth` is supported. I will check if other properties could be configured using `Serilog.Settings.Configuration`