### PR TITLE
Improve cycles detection by taking exception itself into account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `OperationCanceledExceptionDestructurer` and `TaskCanceledExceptionDestructurer`
 - Extend reflection based destructurer with custom `Task` and `CancellationToken` destructuring code
 
+### Fixed
+- 
+
 ## [4.1.0] - 2018-03-27
 
 ### Fixed
-- Race condition in `ReflectionBasedDestructurer` cache
+- Reflection based destructurer handles a case when exception itself is a part of object graph cycle
 
 ### Changed
 - Improved performance of reflection based destructurer using dynamic code generation

--- a/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
+++ b/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
@@ -63,9 +63,9 @@ namespace Serilog.Exceptions.Core
         }
 
         /// <inheritdoc cref="IExceptionPropertiesBag.ContainsProperty"/>
-        public bool ContainsProperty(string key)
-        {
-            return this.properties.ContainsKey(key);
-        }
+        public bool ContainsProperty(string key) => this.properties.ContainsKey(key);
+
+        /// <inheritdoc cref="IExceptionPropertiesBag.GetProperty"/>
+        public object GetProperty(string key) => this.properties[key];
     }
 }

--- a/Source/Serilog.Exceptions/Core/IExceptionPropertiesBag.cs
+++ b/Source/Serilog.Exceptions/Core/IExceptionPropertiesBag.cs
@@ -20,15 +20,22 @@ namespace Serilog.Exceptions.Core
         /// <summary>
         /// Adds a property to the bag.
         /// </summary>
-        /// <param name="key">The key</param>
-        /// <param name="value">The value</param>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
         void AddProperty(string key, object value);
 
         /// <summary>
         /// Returns true if given key is already present in the bag.
         /// </summary>
-        /// <param name="key">The key</param>
+        /// <param name="key">The key.</param>
         /// <returns>True if given key is already present.</returns>
         bool ContainsProperty(string key);
+
+        /// <summary>
+        /// Returns value of a given key.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <returns>Value of a given key.</returns>
+        object GetProperty(string key);
     }
 }

--- a/Tests/Serilog.Exceptions.Benchmark/ExceptionPropertiesBag.cs
+++ b/Tests/Serilog.Exceptions.Benchmark/ExceptionPropertiesBag.cs
@@ -54,5 +54,6 @@ namespace Serilog.Exceptions.Benchmark
         }
 
         public bool ContainsProperty(string key) => this.properties.ContainsKey(key);
+        public object GetProperty(string key) => this.properties[key];
     }
 }

--- a/Tests/Serilog.Exceptions.Benchmark/Serilog.Exceptions.Benchmark.csproj
+++ b/Tests/Serilog.Exceptions.Benchmark/Serilog.Exceptions.Benchmark.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.2" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.3" />
     <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.0" />

--- a/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
+++ b/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="FluentAssertions" Version="5.5.0" />
+    <PackageReference Include="FluentAssertions" Version="5.5.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Moq" Version="4.10.0" />

--- a/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
+++ b/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="FluentAssertions" Version="5.5.1" />
+    <PackageReference Include="FluentAssertions" Version="5.5.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Moq" Version="4.10.0" />


### PR DESCRIPTION
`ReflectionBasedDestructurer` correctly handled all objects that could be part of an object graph cycle, excluding the exception object itself. 

This PR aims to fix that. New abstraction was introduced that unifies usage of `Dictionary<string, object>` for all ordinary objects and `ExceptionPropertiesBag` for the root exception. The abstraction allows adding `$id` and `$ref` markers whenever necessary for both kinds of objects.

The scenario that will be improved by this PR is the unlikely case of a root exception being part of object cycle. Without this PR, only the second instance of exception object in the object graph would get `$id` and be part of the cycle-breaking mechanism. With this PR, root exception gets '$id` property and the resulting payload can be substantially smaller.

I still need to think about this and possibly refactor the code, but appropriate tests were added and the mechanism is completed.