### PR TITLE
Upgrade to .NET Core SDK 5.0.100

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
-# Version: 1.6.2 (Using https://semver.org/)
-# Updated: 2020-11-02
+# Version: 2.0.0 (Using https://semver.org/)
+# Updated: 2020-11-15
 # See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
 # See https://github.com/RehanSaeed/EditorConfig for updates to this file.
 # See http://EditorConfig.org for more information about .editorconfig files.
@@ -80,106 +80,115 @@ indent_style = tab
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions
 ##########################################
 
+# Default Severity for .NET Code Style
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/configuration-options#scope
+dotnet_analyzer_diagnostic.severity = warning
+
 # .NET Code Style Settings
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#net-code-style-settings
 [*.{cs,csx,cake,vb,vbx}]
 # "this." and "Me." qualifiers
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#this-and-me
-dotnet_style_qualification_for_field = true:warning
-dotnet_style_qualification_for_property = true:warning
-dotnet_style_qualification_for_method = true:warning
-dotnet_style_qualification_for_event = true:warning
+dotnet_style_qualification_for_field = true
+dotnet_style_qualification_for_property = true
+dotnet_style_qualification_for_method = true
+dotnet_style_qualification_for_event = true
 # Language keywords instead of framework type names for type references
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#language-keywords
-dotnet_style_predefined_type_for_locals_parameters_members = true:warning
-dotnet_style_predefined_type_for_member_access = true:warning
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
 # Modifier preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#normalize-modifiers
-dotnet_style_require_accessibility_modifiers = always:warning
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
-visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:warning
-dotnet_style_readonly_field = true:warning
+dotnet_style_require_accessibility_modifiers = always
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async
+dotnet_style_readonly_field = true
 # Parentheses preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#parentheses-preferences
-dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
-dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
-dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:warning
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:suggestion
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = always_for_clarity
 # Expression-level preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#expression-level-preferences
-dotnet_style_object_initializer = true:warning
-dotnet_style_collection_initializer = true:warning
-dotnet_style_explicit_tuple_names = true:warning
-dotnet_style_prefer_inferred_tuple_names = true:warning
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
-dotnet_style_prefer_auto_properties = true:warning
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
-dotnet_style_prefer_conditional_expression_over_assignment = false:suggestion
-dotnet_style_prefer_conditional_expression_over_return = false:suggestion
-dotnet_style_prefer_compound_assignment = true:warning
+dotnet_style_object_initializer = true
+dotnet_style_collection_initializer = true
+dotnet_style_explicit_tuple_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_auto_properties = true
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+dotnet_style_prefer_conditional_expression_over_assignment = false
+dotnet_diagnostic.IDE0045.severity = suggestion
+dotnet_style_prefer_conditional_expression_over_return = false
+dotnet_diagnostic.IDE0046.severity = suggestion
+dotnet_style_prefer_compound_assignment = true
 # Null-checking preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#null-checking-preferences
-dotnet_style_coalesce_expression = true:warning
-dotnet_style_null_propagation = true:warning
+dotnet_style_coalesce_expression = true
+dotnet_style_null_propagation = true
 # Parameter preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#parameter-preferences
-dotnet_code_quality_unused_parameters = all:warning
+dotnet_code_quality_unused_parameters = all
 # More style options (Undocumented)
 # https://github.com/MicrosoftDocs/visualstudio-docs/issues/3641
 dotnet_style_operator_placement_when_wrapping = end_of_line
 # https://github.com/dotnet/roslyn/pull/40070
-dotnet_style_prefer_simplified_interpolation = true:warning
+dotnet_style_prefer_simplified_interpolation = true
 
 # C# Code Style Settings
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#c-code-style-settings
 [*.{cs,csx,cake}]
 # Implicit and explicit types
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#implicit-and-explicit-types
-csharp_style_var_for_built_in_types = true:warning
-csharp_style_var_when_type_is_apparent = true:warning
-csharp_style_var_elsewhere = true:warning
+csharp_style_var_for_built_in_types = true
+csharp_style_var_when_type_is_apparent = true
+csharp_style_var_elsewhere = true
 # Expression-bodied members
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#expression-bodied-members
-csharp_style_expression_bodied_methods = true:warning
-csharp_style_expression_bodied_constructors = true:warning
-csharp_style_expression_bodied_operators = true:warning
-csharp_style_expression_bodied_properties = true:warning
-csharp_style_expression_bodied_indexers = true:warning
-csharp_style_expression_bodied_accessors = true:warning
-csharp_style_expression_bodied_lambdas = true:warning
-csharp_style_expression_bodied_local_functions = true:warning
+csharp_style_expression_bodied_methods = true
+csharp_style_expression_bodied_constructors = true
+csharp_style_expression_bodied_operators = true
+csharp_style_expression_bodied_properties = true
+csharp_style_expression_bodied_indexers = true
+csharp_style_expression_bodied_accessors = true
+csharp_style_expression_bodied_lambdas = true
+csharp_style_expression_bodied_local_functions = true
 # Pattern matching
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#pattern-matching
-csharp_style_pattern_matching_over_is_with_cast_check = true:warning
-csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_pattern_matching_over_is_with_cast_check = true
+csharp_style_pattern_matching_over_as_with_null_check = true
 # Inlined variable declarations
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#inlined-variable-declarations
-csharp_style_inlined_variable_declaration = true:warning
+csharp_style_inlined_variable_declaration = true
 # Expression-level preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#expression-level-preferences
-csharp_prefer_simple_default_expression = true:warning
+csharp_prefer_simple_default_expression = true
 # "Null" checking preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#c-null-checking-preferences
-csharp_style_throw_expression = true:warning
-csharp_style_conditional_delegate_call = true:warning
+csharp_style_throw_expression = true
+csharp_style_conditional_delegate_call = true
 # Code block preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#code-block-preferences
-csharp_prefer_braces = true:warning
+csharp_prefer_braces = true
 # Unused value preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#unused-value-preferences
-csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion
-csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable
+dotnet_diagnostic.IDE0058.severity = suggestion
+csharp_style_unused_value_assignment_preference = discard_variable
+dotnet_diagnostic.IDE0059.severity = suggestion
 # Index and range preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#index-and-range-preferences
-csharp_style_prefer_index_operator = true:warning
-csharp_style_prefer_range_operator = true:warning
+csharp_style_prefer_index_operator = true
+csharp_style_prefer_range_operator = true
 # Miscellaneous preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#miscellaneous-preferences
-csharp_style_deconstructed_variable_declaration = true:warning
-csharp_style_pattern_local_over_anonymous_function = true:warning
-csharp_using_directive_placement = inside_namespace:warning
-csharp_prefer_static_local_function = true:warning
-csharp_prefer_simple_using_statement = true:suggestion
+csharp_style_deconstructed_variable_declaration = true
+csharp_style_pattern_local_over_anonymous_function = true
+csharp_using_directive_placement = inside_namespace
+csharp_prefer_static_local_function = true
+csharp_prefer_simple_using_statement = true
+dotnet_diagnostic.IDE0063.severity = suggestion
 
 ##########################################
 # .NET Formatting Conventions

--- a/Benchmarks/Serilog.Exceptions.Benchmark/ExceptionPropertiesBag.cs
+++ b/Benchmarks/Serilog.Exceptions.Benchmark/ExceptionPropertiesBag.cs
@@ -40,7 +40,7 @@ namespace Serilog.Exceptions.Benchmark
                     $"Cannot add exception property '{key}' to bag, after results were already collected");
             }
 
-            if (this.filter is object)
+            if (this.filter is not null)
             {
                 if (this.filter.ShouldPropertyBeFiltered(this.exception, key, value))
                 {

--- a/Benchmarks/Serilog.Exceptions.Benchmark/Serilog.Exceptions.Benchmark.csproj
+++ b/Benchmarks/Serilog.Exceptions.Benchmark/Serilog.Exceptions.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup Label="Build">
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -15,14 +15,14 @@
     <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.1" />
-    <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
   </ItemGroup>
 
-  <ItemGroup Label="Package References (.NET Core)" Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Label="Package References (.NET)" Condition=" '$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>
 
-  <ItemGroup Label="References (.NET Framework)" Condition=" '$(TargetFramework)' == 'net461' ">
+  <ItemGroup Label="References (.NET Framework)" Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
 
   <PropertyGroup Label="Build">
     <LangVersion>latest</LangVersion>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
     <NeutralLanguage>en-GB</NeutralLanguage>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -21,7 +22,6 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" PrivateAssets="All" Version="3.3.1" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="All" Version="16.8.55" />
     <PackageReference Include="MinVer" PrivateAssets="All" Version="2.3.1" />

--- a/Source/Serilog.Exceptions.EntityFrameworkCore/Serilog.Exceptions.EntityFrameworkCore.csproj
+++ b/Source/Serilog.Exceptions.EntityFrameworkCore/Serilog.Exceptions.EntityFrameworkCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Source/Serilog.Exceptions.MsSqlServer/Serilog.Exceptions.MsSqlServer.csproj
+++ b/Source/Serilog.Exceptions.MsSqlServer/Serilog.Exceptions.MsSqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
@@ -10,13 +10,12 @@
     <PackageTags>Serilog;Exception;Log;Logging;Detail;Details;SQL;Server</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.0" />
-  </ItemGroup>
-
-
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Source\Serilog.Exceptions\Serilog.Exceptions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Label="Package References">
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Source/Serilog.Exceptions.SqlServer/Serilog.Exceptions.SqlServer.csproj
+++ b/Source/Serilog.Exceptions.SqlServer/Serilog.Exceptions.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>netstandard2.0;netstandard1.6;netstandard1.3;net461;net472</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0;netstandard1.6;netstandard1.3;net472;net461</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
@@ -10,12 +10,11 @@
     <PackageTags>Serilog;Exception;Log;Logging;Detail;Details;SQL;Server</PackageTags>
   </PropertyGroup>
 
-
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Source\Serilog.Exceptions\Serilog.Exceptions.csproj" />
   </ItemGroup>
 
-  <ItemGroup Label="Package References (.NET Standard)" Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.6' OR '$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup Label="Package References (.NET)" Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.6' OR '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
   </ItemGroup>
 

--- a/Source/Serilog.Exceptions/Core/DestructuringOptionsBuilder.cs
+++ b/Source/Serilog.Exceptions/Core/DestructuringOptionsBuilder.cs
@@ -100,7 +100,7 @@ namespace Serilog.Exceptions.Core
         /// <returns>Options builder for method chaining.</returns>
         public DestructuringOptionsBuilder WithFilter(IExceptionPropertyFilter filter)
         {
-            if (this.Filter is object)
+            if (this.Filter is not null)
             {
                 throw new InvalidOperationException(
                     string.Format(CultureInfo.InvariantCulture, Resources.FilterAlreadySet, nameof(CompositeExceptionPropertyFilter)));

--- a/Source/Serilog.Exceptions/Core/ExceptionEnricher.cs
+++ b/Source/Serilog.Exceptions/Core/ExceptionEnricher.cs
@@ -60,11 +60,11 @@ namespace Serilog.Exceptions.Core
                 throw new ArgumentNullException(nameof(propertyFactory));
             }
 
-            if (logEvent.Exception is object)
+            if (logEvent.Exception is not null)
             {
                 var dataDictionary = this.DestructureException(logEvent.Exception);
 
-                if (dataDictionary is object)
+                if (dataDictionary is not null)
                 {
                     logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(
                         this.destructuringOptions.RootName,

--- a/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
+++ b/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
@@ -48,7 +48,7 @@ namespace Serilog.Exceptions.Core
                 throw new InvalidOperationException($"Cannot add exception property '{key}' to bag, after results were already collected");
             }
 
-            if (this.filter is object)
+            if (this.filter is not null)
             {
                 if (this.filter.ShouldPropertyBeFiltered(this.exception, key, value))
                 {

--- a/Source/Serilog.Exceptions/Destructurers/ExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ExceptionDestructurer.cs
@@ -179,7 +179,7 @@ namespace Serilog.Exceptions.Destructurers
                 foreach (var dangerousType in GetNotHandledByMonoTypes())
                 {
                     var type = Type.GetType(dangerousType);
-                    if (type is object)
+                    if (type is not null)
                     {
                         targetTypes.Add(type);
                     }
@@ -253,13 +253,13 @@ namespace Serilog.Exceptions.Destructurers
             propertiesBag.AddProperty(nameof(Exception.StackTrace), exception.StackTrace);
 
 #if NET461 || NET472
-            if (exception.TargetSite is object)
+            if (exception.TargetSite is not null)
             {
                 propertiesBag.AddProperty(nameof(Exception.TargetSite), exception.TargetSite.ToString());
             }
 #endif
 
-            if (exception.InnerException is object)
+            if (exception.InnerException is not null)
             {
                 propertiesBag.AddProperty(nameof(Exception.InnerException), innerDestructure(exception.InnerException));
             }

--- a/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
@@ -176,7 +176,7 @@ namespace Serilog.Exceptions.Destructurers
                 catch (TargetInvocationException targetInvocationException)
                 {
                     var innerException = targetInvocationException.InnerException;
-                    if (innerException is object)
+                    if (innerException is not null)
                     {
                         addPropertyAction(property.Name, $"threw {innerException.GetType().FullName}: {innerException.Message}");
                     }
@@ -361,7 +361,7 @@ namespace Serilog.Exceptions.Destructurers
                 catch (TargetInvocationException targetInvocationException)
                 {
                     var innerException = targetInvocationException.InnerException;
-                    if (innerException is object)
+                    if (innerException is not null)
                     {
                         values.Add(property.Name, $"threw {innerException.GetType().FullName}: {innerException.Message}");
                     }

--- a/Source/Serilog.Exceptions/Destructurers/ReflectionTypeLoadExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ReflectionTypeLoadExceptionDestructurer.cs
@@ -24,7 +24,7 @@ namespace Serilog.Exceptions.Destructurers
 
 #pragma warning disable CA1062 // Validate arguments of public methods
             var reflectionTypeLoadException = (ReflectionTypeLoadException)exception;
-            if (reflectionTypeLoadException.LoaderExceptions is object)
+            if (reflectionTypeLoadException.LoaderExceptions is not null)
             {
                 propertiesBag.AddProperty(
                     nameof(ReflectionTypeLoadException.LoaderExceptions),

--- a/Source/Serilog.Exceptions/Destructurers/TaskCanceledExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/TaskCanceledExceptionDestructurer.cs
@@ -52,7 +52,7 @@ namespace Serilog.Exceptions.Destructurers
             var taskStatus = task.Status.ToString("G");
             var taskCreationOptions = task.CreationOptions.ToString("F");
 
-            if (task.IsFaulted && task.Exception is object)
+            if (task.IsFaulted && task.Exception is not null)
             {
                 return new
                 {

--- a/Source/Serilog.Exceptions/Serilog.Exceptions.csproj
+++ b/Source/Serilog.Exceptions/Serilog.Exceptions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>netstandard2.0;netstandard1.6;netstandard1.3;net461;net472</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0;netstandard1.6;netstandard1.3;net472;net461</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
@@ -14,7 +14,7 @@
     <PackageReference Include="Serilog" Version="2.8.0" />
   </ItemGroup>
 
-  <ItemGroup Label="Package References (.NET Standard)" Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.6' OR '$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup Label="Package References (.NET)" Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.6' OR '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>
 

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ExceptionDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ExceptionDestructurerTest.cs
@@ -22,7 +22,7 @@ namespace Serilog.Exceptions.Test.Destructurers
 
             var targetTypes = destructurer.TargetTypes;
 
-            if (Type.GetType("System.Diagnostics.Eventing.Reader.EventLogInvalidDataException, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089") is object)
+            if (Type.GetType("System.Diagnostics.Eventing.Reader.EventLogInvalidDataException, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089") is not null)
             {
                 // Full .NET
                 targetTypes.Should().Contain(t => t.FullName == "System.Diagnostics.Eventing.Reader.EventLogInvalidDataException");

--- a/Tests/Serilog.Exceptions.Test/Destructurers/LogJsonOutputUtils.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/LogJsonOutputUtils.cs
@@ -87,7 +87,7 @@ namespace Serilog.Exceptions.Test.Destructurers
         {
             var paramNameProperty = ExtractProperty(jObject, propertyKey);
             var paramName = Assert.IsType<JValue>(paramNameProperty.Value);
-            if (paramName.Value is object)
+            if (paramName.Value is not null)
             {
                 var paramNameString = paramName.Value.Should()
                     .BeOfType<string>($"{propertyKey} value was expected to a string").Which;

--- a/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
+++ b/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Signing">
@@ -16,7 +16,7 @@
 
   <ItemGroup Label="Package References">
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/Tools/ExceptionFinderTool/ExceptionFinderTool.csproj
+++ b/Tools/ExceptionFinderTool/ExceptionFinderTool.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup Label="Build">
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp3.0;netcoreapp2.2;netcoreapp2.1;netcoreapp2.0;net461;net472</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net472;net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup Label="Package References (.NET Core)" Condition=" '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'netcoreapp3.0' OR '$(TargetFramework)' == 'netcoreapp2.2' OR '$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'netcoreapp2.0'">
+  <ItemGroup Label="Package References (.NET)" Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>
 

--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,7 @@
 var target = Argument("Target", "Default");
 var configuration =
     HasArgument("Configuration") ? Argument<string>("Configuration") :
-    EnvironmentVariable("Configuration") is object ? EnvironmentVariable("Configuration") :
+    EnvironmentVariable("Configuration") is not null ? EnvironmentVariable("Configuration") :
     "Release";
 
 var artefactsDirectory = Directory("./Artefacts");
@@ -45,15 +45,17 @@ Task("Test")
             project.ToString(),
             new DotNetCoreTestSettings()
             {
+                Collectors = new string[] { "XPlat Code Coverage" },
                 Configuration = configuration,
-                Logger = $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
+                Loggers = new string[]
+                {
+                    $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
+                    $"html;LogFileName={project.GetFilenameWithoutExtension()}.html",
+                },
                 NoBuild = true,
                 NoRestore = true,
                 ResultsDirectory = artefactsDirectory,
-                ArgumentCustomization = x => x
-                    .Append("--blame")
-                    .AppendSwitch("--logger", $"html;LogFileName={project.GetFilenameWithoutExtension()}.html")
-                    .Append("--collect:\"XPlat Code Coverage\""),
+                ArgumentCustomization = x => x.Append("--blame"),
             });
     });
 

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "0.38.5",
+      "version": "1.0.0-rc0001",
       "commands": [
         "dotnet-cake"
       ]

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.403"
+    "rollForward": "latestMajor",
+    "version": "5.0.100"
   }
 }


### PR DESCRIPTION
- Upgrade to .NET Core SDK 5.0.100.
- Use latestMajor .NET SDK.
- Bump Cake.Tool from 0.38.5 to 1.0.0.
- Update the `.editorconfig` file which has changed in a breaking way (https://github.com/RehanSaeed/EditorConfig/pull/42) to support VS 16.8.
- Enable `EnforceCodeStyleInBuild` (This is awesome).
- Fix all the new warnings.
- Switch from `is object` to `is not null`. This has been on my mind for a long time. There is a lot more that could be done but getting some C# 9 in early.