### PR TITLE
Up Bump .NET SDK from 5.0.100 to 5.0.102

### DIFF
--- a/Benchmarks/Serilog.Exceptions.Benchmark/Point.cs
+++ b/Benchmarks/Serilog.Exceptions.Benchmark/Point.cs
@@ -8,6 +8,8 @@ namespace Serilog.Exceptions.Benchmark
 
         public int Y { get; set; }
 
+#pragma warning disable IDE0052 // Remove unread private members
         private int Z { get; set; }
+#pragma warning restore IDE0052 // Remove unread private members
     }
 }

--- a/Tests/.editorconfig
+++ b/Tests/.editorconfig
@@ -22,7 +22,6 @@ dotnet_diagnostic.SA1602.severity = none
 # Custom
 ##########################################
 
-[*.cs]
 # CA1032: Implement standard exception constructors
 # Justification: These are unit tests
 # https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1032
@@ -42,3 +41,8 @@ dotnet_diagnostic.CA1303.severity = none
 # Justification: Test method names contain underscores
 # https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1707
 dotnet_diagnostic.CA1707.severity = none
+
+# CA2201: Do not raise reserved exception types
+# Justification: These are unit tests
+# https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2201
+dotnet_diagnostic.CA2201.severity = none

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ build_script:
       Invoke-WebRequest "https://dot.net/v1/dotnet-install.sh" -OutFile "./dotnet-install.sh"
       sudo chmod u+x dotnet-install.sh
       if ($isMacOS) {
-        sudo ./dotnet-install.sh --jsonfile global.json --install-dir '/Users/appveyor/.dotnet'
+        sudo ./dotnet-install.sh --jsonfile global.json --install-dir '/usr/local/share/dotnet'
       } else {
         sudo ./dotnet-install.sh --jsonfile global.json --install-dir '/usr/share/dotnet'
       }

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.0.0-rc0001",
+      "version": "1.0.0-rc0002",
       "commands": [
         "dotnet-cake"
       ]

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestMajor",
-    "version": "5.0.100"
+    "version": "5.0.102"
   }
 }


### PR DESCRIPTION
- Bump .NET SDK from 5.0.100 to 5.0.102.
- Bump cake.tool to RC2.
- Fix warnings.
- Fix AppVeyor Mac OS .NET SDK install path.
