### PR TITLE
Bump StyleCop.Analyzers from 1.1.118 to 1.2.0-beta.321

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="All" Version="16.8.55" />
     <PackageReference Include="MinVer" PrivateAssets="All" Version="2.4.0" />
-    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.118" />
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.2.0-beta.321" />
   </ItemGroup>
 
 </Project>

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.0.0-rc0002",
+      "version": "1.0.0-rc0003",
       "commands": [
         "dotnet-cake"
       ]


### PR DESCRIPTION
- Bump StyleCop.Analyzers from 1.1.118 to 1.2.0-beta.321, this allows use of new C# features without warnings.
- Bump dotnet-cake from 1.0.0-rc0002 to 1.0.0-rc0003.