### PR TITLE
Fix reflection based destructuring for redefined property

### DIFF
--- a/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
+++ b/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
@@ -69,6 +69,9 @@ namespace Serilog.Exceptions.Core
         /// <inheritdoc />
         public bool ContainsProperty(string key) => this.properties.ContainsKey(key);
 
+        private static string GetReplacementKey(string key) => key + "$";
+
+
         /// <summary>
         /// We want to be as robust as possible
         /// so even in case of multiple properties with the same name
@@ -80,7 +83,7 @@ namespace Serilog.Exceptions.Core
             var i = 0;
             while (!this.properties.TryAdd(key, value) && i < AcceptableNumberOfSameNameProperties)
             {
-                key += "$";
+                key = GetReplacementKey(key);
                 i++;
             }
 #else
@@ -97,12 +100,13 @@ namespace Serilog.Exceptions.Core
             var i = 0;
             while (this.properties.ContainsKey(key) && i < AcceptableNumberOfSameNameProperties)
             {
-                key += "$";
+                key = GetReplacementKey(key);
                 i++;
             }
 
             return key;
         }
 #endif
+
     }
 }

--- a/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
+++ b/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
@@ -59,10 +59,13 @@ namespace Serilog.Exceptions.Core
             this.AddPairToProperties(key, value);
         }
 
+        /// <inheritdoc />
+        public bool ContainsProperty(string key) => this.properties.ContainsKey(key);
+
         private void AddPairToProperties(string key, object? value)
         {
 #if NET5_0
-            int i = 0;
+            var i = 0;
             while (!this.properties.TryAdd(key, value) && i < 5)
             {
                 key += "$";
@@ -82,7 +85,6 @@ namespace Serilog.Exceptions.Core
         /// </summary>
         private string MakeSureKeyIsUnique(string key)
         {
-
             var i = 0;
             while (this.properties.ContainsKey(key) && i < 5)
             {
@@ -92,8 +94,5 @@ namespace Serilog.Exceptions.Core
 
             return key;
         }
-
-        /// <inheritdoc />
-        public bool ContainsProperty(string key) => this.properties.ContainsKey(key);
     }
 }

--- a/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
+++ b/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
@@ -56,9 +56,23 @@ namespace Serilog.Exceptions.Core
                 }
             }
 
+            this.AddPairToProperties(key, value);
+        }
+
+        private void AddPairToProperties(string key, object? value)
+        {
+#if NET5_0
+            int i = 0;
+            while (!this.properties.TryAdd(key, value) && i < 5)
+            {
+                key += "$";
+                i++;
+            }
+#else
             key = this.MakeSureKeyIsUnique(key);
 
             this.properties.Add(key, value);
+#endif
         }
 
         /// <summary>
@@ -68,6 +82,7 @@ namespace Serilog.Exceptions.Core
         /// </summary>
         private string MakeSureKeyIsUnique(string key)
         {
+
             var i = 0;
             while (this.properties.ContainsKey(key) && i < 5)
             {

--- a/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
+++ b/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
@@ -56,7 +56,26 @@ namespace Serilog.Exceptions.Core
                 }
             }
 
+            key = this.MakeSureKeyIsUnique(key);
+
             this.properties.Add(key, value);
+        }
+
+        /// <summary>
+        /// We want to be as robust as possible
+        /// so even in case of multiple properties with the same name
+        /// we want to at least try carrying on and keep working.
+        /// </summary>
+        private string MakeSureKeyIsUnique(string key)
+        {
+            var i = 0;
+            while (this.properties.ContainsKey(key) && i < 5)
+            {
+                key += "$";
+                i++;
+            }
+
+            return key;
         }
 
         /// <inheritdoc />

--- a/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
+++ b/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
@@ -91,6 +91,7 @@ namespace Serilog.Exceptions.Core
             this.properties.Add(key, value);
 #endif
         }
+
 #if !NET5_0
         private string MakeSureKeyIsUnique(string key)
         {

--- a/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
+++ b/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
@@ -78,6 +78,7 @@ namespace Serilog.Exceptions.Core
 #endif
         }
 
+#if !NET5_0
         /// <summary>
         /// We want to be as robust as possible
         /// so even in case of multiple properties with the same name
@@ -95,4 +96,5 @@ namespace Serilog.Exceptions.Core
             return key;
         }
     }
+#endif
 }

--- a/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
+++ b/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
@@ -16,7 +16,7 @@ namespace Serilog.Exceptions.Core
         private const int AcceptableNumberOfSameNameProperties = 5;
         private readonly Exception exception;
         private readonly IExceptionPropertyFilter? filter;
-        private readonly Dictionary<string, object?> properties = new ();
+        private readonly Dictionary<string, object?> properties = new();
 
         /// <summary>
         /// We keep a note on whether the results were collected to be sure that after that there are no changes. This
@@ -71,7 +71,6 @@ namespace Serilog.Exceptions.Core
 
         private static string GetReplacementKey(string key) => key + "$";
 
-
         /// <summary>
         /// We want to be as robust as possible
         /// so even in case of multiple properties with the same name
@@ -92,9 +91,7 @@ namespace Serilog.Exceptions.Core
             this.properties.Add(key, value);
 #endif
         }
-
 #if !NET5_0
-        
         private string MakeSureKeyIsUnique(string key)
         {
             var i = 0;

--- a/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
+++ b/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
@@ -95,6 +95,6 @@ namespace Serilog.Exceptions.Core
 
             return key;
         }
-    }
 #endif
+    }
 }

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ReflectionBasedDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ReflectionBasedDestructurerTest.cs
@@ -191,8 +191,6 @@ namespace Serilog.Exceptions.Test.Destructurers
             Assert.Equal("ABC", destructuredStructDictionary[nameof(TestClass.ReferenceType)]);
         }
 
-
-
         [Fact]
         public void DestructuringDepthIsLimitedByConfiguredDepth()
         {
@@ -390,7 +388,6 @@ namespace Serilog.Exceptions.Test.Destructurers
         [Fact]
         public void CanDestructureObjectWithRedefinedProperty()
         {
-
             var exception = new TestExceptionClassWithNewDefinition() { PublicProperty = 20 };
 
             var propertiesBag = new ExceptionPropertiesBag(exception);
@@ -399,8 +396,6 @@ namespace Serilog.Exceptions.Test.Destructurers
             var properties = propertiesBag.GetResultDictionary();
             var info = properties[nameof(TestExceptionClassWithNewDefinition.PublicProperty)];
         }
-
-        
 
         private static void Test_ResultOfReflectionDestructurerShouldBeEquivalentToCustomOne(
             Exception exception,

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ReflectionBasedDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ReflectionBasedDestructurerTest.cs
@@ -9,6 +9,7 @@ namespace Serilog.Exceptions.Test.Destructurers
     using Serilog.Exceptions.Core;
     using Serilog.Exceptions.Destructurers;
     using Xunit;
+    using Xunit.Abstractions;
     using static LogJsonOutputUtils;
 
     public class ReflectionBasedDestructurerTest
@@ -189,6 +190,8 @@ namespace Serilog.Exceptions.Test.Destructurers
             Assert.Equal(10, destructuredStructDictionary[nameof(TestClass.ValueType)]);
             Assert.Equal("ABC", destructuredStructDictionary[nameof(TestClass.ReferenceType)]);
         }
+
+
 
         [Fact]
         public void DestructuringDepthIsLimitedByConfiguredDepth()
@@ -384,6 +387,21 @@ namespace Serilog.Exceptions.Test.Destructurers
             Assert.Equal(baseClass.HiddenProperty, info?[$"{typeof(BaseClass).FullName}.{nameof(BaseClass.HiddenProperty)}"]);
         }
 
+        [Fact]
+        public void CanDestructureObjectWithRedefinedProperty()
+        {
+
+            var exception = new TestExceptionClassWithNewDefinition() { PublicProperty = 20 };
+
+            var propertiesBag = new ExceptionPropertiesBag(exception);
+            CreateReflectionBasedDestructurer().Destructure(exception, propertiesBag, EmptyDestructurer());
+
+            var properties = propertiesBag.GetResultDictionary();
+            var info = properties[nameof(TestExceptionClassWithNewDefinition.PublicProperty)];
+        }
+
+        
+
         private static void Test_ResultOfReflectionDestructurerShouldBeEquivalentToCustomOne(
             Exception exception,
             IExceptionDestructurer customDestructurer)
@@ -576,6 +594,11 @@ namespace Serilog.Exceptions.Test.Destructurers
             public int ValueType { get; set; }
 
             public string? ReferenceType { get; set; }
+        }
+
+        internal class TestExceptionClassWithNewDefinition : TestException
+        {
+            public new int PublicProperty { get; set; }
         }
 
         internal class BaseClass

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ReflectionBasedDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ReflectionBasedDestructurerTest.cs
@@ -397,6 +397,25 @@ namespace Serilog.Exceptions.Test.Destructurers
             var info = properties[nameof(TestExceptionClassWithNewDefinition.PublicProperty)];
         }
 
+        [Fact]
+        public void CanDestructureObjectWithDataWithRedefinedProperty()
+        {
+            var exception = new RecursiveException
+            {
+                Node = new RecursiveNodeWithRedefinedProperty
+                {
+                    Name = 123,
+                },
+            };
+
+            var propertiesBag = new ExceptionPropertiesBag(exception);
+            CreateReflectionBasedDestructurer().Destructure(exception, propertiesBag, EmptyDestructurer());
+
+            var properties = propertiesBag.GetResultDictionary();
+            var parent = (IDictionary<string, object?>?)properties[nameof(RecursiveException.Node)];
+            Assert.Equal(123, parent?[nameof(RecursiveNode.Name)]);
+        }
+
         private static void Test_ResultOfReflectionDestructurerShouldBeEquivalentToCustomOne(
             Exception exception,
             IExceptionDestructurer customDestructurer)
@@ -566,6 +585,11 @@ namespace Serilog.Exceptions.Test.Destructurers
             public string? Name { get; set; }
 
             public RecursiveNode? Child { get; set; }
+        }
+
+        public class RecursiveNodeWithRedefinedProperty : RecursiveNode
+        {
+            public new int Name { get; set; }
         }
 
         public class RecursiveException : Exception


### PR DESCRIPTION
I may prepare another fix to tackle the problem of gathering properties from a type taking into account possible redefinitions.
However, I consider the change proposed here good practice for library robustness.

Fixes #343 