### PR TITLE
Add .NET 6 and C# 10 Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,14 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
+      - name: "Install .NET Core 3.1 SDK"
+        uses: actions/setup-dotnet@v1.8.2
+        with:
+          dotnet-version: "3.1.x"
+      - name: "Install .NET Core 5.0 SDK"
+        uses: actions/setup-dotnet@v1.8.2
+        with:
+          dotnet-version: "5.0.x"
       - name: "Install .NET Core SDK"
         uses: actions/setup-dotnet@v1.8.2
       - name: "Dotnet Tool Restore"

--- a/Benchmarks/Serilog.Exceptions.Benchmark/DestructuringBenchmark.cs
+++ b/Benchmarks/Serilog.Exceptions.Benchmark/DestructuringBenchmark.cs
@@ -13,8 +13,8 @@ namespace Serilog.Exceptions.Benchmark
     [HtmlExporter]
     [CsvMeasurementsExporter]
     [RPlotExporter]
+    [SimpleJob(RuntimeMoniker.Net60)]
     [SimpleJob(RuntimeMoniker.Net472)]
-    [SimpleJob(RuntimeMoniker.Net50)]
     public class DestructuringBenchmark
     {
         private readonly ReflectionBasedDestructurer reflectionBasedDestructurer = new(10);

--- a/Benchmarks/Serilog.Exceptions.Benchmark/ExceptionPropertiesBag.cs
+++ b/Benchmarks/Serilog.Exceptions.Benchmark/ExceptionPropertiesBag.cs
@@ -29,10 +29,14 @@ namespace Serilog.Exceptions.Benchmark
 
         public void AddProperty(string key, object? value)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(key);
+#else
             if (key is null)
             {
                 throw new ArgumentNullException(nameof(key));
             }
+#endif
 
             if (this.resultsCollected)
             {

--- a/Benchmarks/Serilog.Exceptions.Benchmark/Serilog.Exceptions.Benchmark.csproj
+++ b/Benchmarks/Serilog.Exceptions.Benchmark/Serilog.Exceptions.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup Label="Build">
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -18,7 +18,7 @@
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
   </ItemGroup>
 
-  <ItemGroup Label="Package References (.NET)" Condition=" '$(TargetFramework)' == 'net5.0' ">
+  <ItemGroup Label="Package References (.NET)" Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/RehanSaeed/Serilog.Exceptions</PackageProjectUrl>
     <PackageIcon>Icon.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/RehanSaeed/Serilog.Exceptions.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReleaseNotes>https://github.com/RehanSaeed/Serilog.Exceptions/releases</PackageReleaseNotes>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Serilog.Exceptions Banner](Images/Banner.png)
+![Serilog.Exceptions Banner](https://media.githubusercontent.com/media/RehanSaeed/Serilog.Exceptions/main/Images/Banner.png)
 
 [![Serilog.Exceptions NuGet Package](https://img.shields.io/nuget/v/Serilog.Exceptions.svg)](https://www.nuget.org/packages/Serilog.Exceptions/) [![Serilog.Exceptions package in serilog-exceptions feed in Azure Artifacts](https://feeds.dev.azure.com/serilog-exceptions/_apis/public/Packaging/Feeds/8479813c-da6b-4677-b40d-78df8725dc9c/Packages/212043f6-5fe5-4c79-949e-162156b89894/Badge)](https://dev.azure.com/serilog-exceptions/Serilog.Exceptions/_packaging?_a=package&feed=8479813c-da6b-4677-b40d-78df8725dc9c&package=212043f6-5fe5-4c79-949e-162156b89894&preferRelease=true) [![Serilog.Exceptions NuGet Package Downloads](https://img.shields.io/nuget/dt/Serilog.Exceptions)](https://www.nuget.org/packages/Serilog.Exceptions) [![Twitter URL](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/RehanSaeedUK) [![Twitter Follow](https://img.shields.io/twitter/follow/rehansaeeduk.svg?style=social&label=Follow)](https://twitter.com/RehanSaeedUK)
 
@@ -262,7 +262,7 @@ Filtering for other scenarios is also supported:
 
 ## Contributions and Thanks
 
-Please view the [contributing guide](/.github/CONTRIBUTING.md) for more information.
+Please view the [contributing guide](https://github.com/RehanSaeed/Serilog.Enrichers.Span/blob/main/.github/CONTRIBUTING.md) for more information.
 
 - [304NotModified](https://github.com/304NotModified) - Added Markdown syntax highlighting.
 - [joelweiss](https://github.com/joelweiss) - Added Entity Framework Core destructurers.

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Filtering for other scenarios is also supported:
 
 ## Contributions and Thanks
 
-Please view the [contributing guide](https://github.com/RehanSaeed/Serilog.Enrichers.Span/blob/main/.github/CONTRIBUTING.md) for more information.
+Please view the [contributing guide](https://github.com/RehanSaeed/Serilog.Exceptions/blob/main/.github/CONTRIBUTING.md) for more information.
 
 - [304NotModified](https://github.com/304NotModified) - Added Markdown syntax highlighting.
 - [joelweiss](https://github.com/joelweiss) - Added Entity Framework Core destructurers.

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -27,6 +27,7 @@
 
   <ItemGroup Label="Files">
     <None Include="..\..\Images\Icon.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Source/Serilog.Exceptions.EntityFrameworkCore/Serilog.Exceptions.EntityFrameworkCore.csproj
+++ b/Source/Serilog.Exceptions.EntityFrameworkCore/Serilog.Exceptions.EntityFrameworkCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">

--- a/Source/Serilog.Exceptions.EntityFrameworkCore/Serilog.Exceptions.EntityFrameworkCore.csproj
+++ b/Source/Serilog.Exceptions.EntityFrameworkCore/Serilog.Exceptions.EntityFrameworkCore.csproj
@@ -14,8 +14,12 @@
     <ProjectReference Include="..\Serilog.Exceptions\Serilog.Exceptions.csproj" />
   </ItemGroup>
 
-  <ItemGroup Label="Package References">
+  <ItemGroup Label="Package References (.NET 6)" Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Package References (.NET 5)" Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Source/Serilog.Exceptions.EntityFrameworkCore/Serilog.Exceptions.EntityFrameworkCore.csproj
+++ b/Source/Serilog.Exceptions.EntityFrameworkCore/Serilog.Exceptions.EntityFrameworkCore.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Source/Serilog.Exceptions.MsSqlServer/Serilog.Exceptions.MsSqlServer.csproj
+++ b/Source/Serilog.Exceptions.MsSqlServer/Serilog.Exceptions.MsSqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;net472;net461</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">

--- a/Source/Serilog.Exceptions.Refit/Destructurers/ApiExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions.Refit/Destructurers/ApiExceptionDestructurer.cs
@@ -40,9 +40,14 @@ namespace Serilog.Exceptions.Refit.Destructurers
             {
                 // Argument checks are usually done in <see cref="ExceptionDestructurer.Destructure"/>
                 // but as we didn't call this method we need to do the checks here.
+#if NET6_0_OR_GREATER
+                ArgumentNullException.ThrowIfNull(exception);
+                ArgumentNullException.ThrowIfNull(propertiesBag);
+                ArgumentNullException.ThrowIfNull(destructureException);
+#else
                 if (exception is null)
                 {
-                    throw new ArgumentNullException(nameof(propertiesBag));
+                    throw new ArgumentNullException(nameof(exception));
                 }
 
                 if (propertiesBag is null)
@@ -54,6 +59,7 @@ namespace Serilog.Exceptions.Refit.Destructurers
                 {
                     throw new ArgumentNullException(nameof(destructureException));
                 }
+#endif
             }
 
 #pragma warning disable CA1062 // Validate arguments of public methods

--- a/Source/Serilog.Exceptions.Refit/Serilog.Exceptions.Refit.csproj
+++ b/Source/Serilog.Exceptions.Refit/Serilog.Exceptions.Refit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;net472;net461</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">

--- a/Source/Serilog.Exceptions.SqlServer/Serilog.Exceptions.SqlServer.csproj
+++ b/Source/Serilog.Exceptions.SqlServer/Serilog.Exceptions.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net5.0;netstandard2.0;netstandard1.6;netstandard1.3;net472;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;netstandard1.3;net472;net461</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\..\Source\Serilog.Exceptions\Serilog.Exceptions.csproj" />
   </ItemGroup>
 
-  <ItemGroup Label="Package References (.NET)" Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.6' OR '$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup Label="Package References (.NET)" Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
   </ItemGroup>
 

--- a/Source/Serilog.Exceptions/Core/DestructuringOptionsBuilder.cs
+++ b/Source/Serilog.Exceptions/Core/DestructuringOptionsBuilder.cs
@@ -76,10 +76,14 @@ namespace Serilog.Exceptions.Core
         /// <returns>Options builder for method chaining.</returns>
         public DestructuringOptionsBuilder WithDestructurers(IEnumerable<IExceptionDestructurer> destructurers)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(destructurers);
+#else
             if (destructurers is null)
             {
                 throw new ArgumentNullException(nameof(destructurers));
             }
+#endif
 
             this.destructurers.AddRange(destructurers);
             return this;
@@ -127,10 +131,14 @@ namespace Serilog.Exceptions.Core
         /// <exception cref="ArgumentException">Name cannot be null or empty.</exception>
         public DestructuringOptionsBuilder WithRootName(string rootName)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(rootName);
+#else
             if (rootName is null)
             {
                 throw new ArgumentNullException(nameof(rootName));
             }
+#endif
 
             if (rootName.Length == 0)
             {

--- a/Source/Serilog.Exceptions/Core/ExceptionEnricher.cs
+++ b/Source/Serilog.Exceptions/Core/ExceptionEnricher.cs
@@ -50,6 +50,10 @@ namespace Serilog.Exceptions.Core
         /// <param name="propertyFactory">The property factory.</param>
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(logEvent);
+            ArgumentNullException.ThrowIfNull(propertyFactory);
+#else
             if (logEvent is null)
             {
                 throw new ArgumentNullException(nameof(logEvent));
@@ -59,6 +63,7 @@ namespace Serilog.Exceptions.Core
             {
                 throw new ArgumentNullException(nameof(propertyFactory));
             }
+#endif
 
             if (logEvent.Exception is not null)
             {

--- a/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
+++ b/Source/Serilog.Exceptions/Core/ExceptionPropertiesBag.cs
@@ -45,10 +45,14 @@ namespace Serilog.Exceptions.Core
         /// <inheritdoc />
         public void AddProperty(string key, object? value)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(key);
+#else
             if (key is null)
             {
                 throw new ArgumentNullException(nameof(key));
             }
+#endif
 
             if (this.resultsCollected)
             {
@@ -78,7 +82,7 @@ namespace Serilog.Exceptions.Core
         /// </summary>
         private void AddPairToProperties(string key, object? value)
         {
-#if NET5_0
+#if NET5_0_OR_GREATER
             var i = 0;
             while (!this.properties.TryAdd(key, value) && i < AcceptableNumberOfSameNameProperties)
             {
@@ -92,7 +96,7 @@ namespace Serilog.Exceptions.Core
 #endif
         }
 
-#if !NET5_0
+#if !NET5_0_OR_GREATER
         private string MakeSureKeyIsUnique(string key)
         {
             var i = 0;
@@ -105,6 +109,5 @@ namespace Serilog.Exceptions.Core
             return key;
         }
 #endif
-
     }
 }

--- a/Source/Serilog.Exceptions/Destructurers/ExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ExceptionDestructurer.cs
@@ -71,6 +71,12 @@ namespace Serilog.Exceptions.Destructurers
                         typeof(System.Data.SyntaxErrorException),
                         typeof(System.Data.VersionNotFoundException),
 #endif
+#if NET461 || NET472
+                        typeof(System.Diagnostics.Eventing.Reader.EventLogInvalidDataException),
+                        typeof(System.Diagnostics.Eventing.Reader.EventLogNotFoundException),
+                        typeof(System.Diagnostics.Eventing.Reader.EventLogProviderDisabledException),
+                        typeof(System.Diagnostics.Eventing.Reader.EventLogReadingException),
+#endif
                         typeof(System.Diagnostics.Tracing.EventSourceException),
                         typeof(System.DataMisalignedException),
                         typeof(System.DivideByZeroException),
@@ -105,6 +111,11 @@ namespace Serilog.Exceptions.Destructurers
                         typeof(System.IO.IsolatedStorage.IsolatedStorageException),
 #endif
                         typeof(System.IO.PathTooLongException),
+#if NET461 || NET472
+                        typeof(System.Management.Instrumentation.InstanceNotFoundException),
+                        typeof(System.Management.Instrumentation.InstrumentationBaseException),
+                        typeof(System.Management.Instrumentation.InstrumentationException),
+#endif
                         typeof(System.MemberAccessException),
                         typeof(System.MethodAccessException),
 #if !NETSTANDARD1_3
@@ -190,16 +201,6 @@ namespace Serilog.Exceptions.Destructurers
                     };
 #pragma warning restore IDE0001 // Simplify Names
 
-#if NET461 || NET472
-                foreach (var dangerousType in GetNotHandledByMonoTypes())
-                {
-                    var type = Type.GetType(dangerousType);
-                    if (type is not null)
-                    {
-                        targetTypes.Add(type);
-                    }
-                }
-#endif
                 return targetTypes.ToArray();
             }
         }
@@ -285,24 +286,5 @@ namespace Serilog.Exceptions.Destructurers
                 propertiesBag.AddProperty(nameof(Exception.InnerException), innerDestructure(exception.InnerException));
             }
         }
-
-#if NET461 || NET472
-        /// <summary>
-        /// Get types that are currently not handled by mono and could raise a LoadTypeException.
-        /// </summary>
-        /// <returns>List of type names.</returns>
-        private static string[] GetNotHandledByMonoTypes() =>
-            new string[]
-            {
-                "System.Diagnostics.Eventing.Reader.EventLogInvalidDataException, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
-                "System.Diagnostics.Eventing.Reader.EventLogNotFoundException, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
-                "System.Diagnostics.Eventing.Reader.EventLogProviderDisabledException, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
-                "System.Diagnostics.Eventing.Reader.EventLogReadingException, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
-                "System.Diagnostics.Tracing.EventSourceException, mscorlib, Version=4.0.0.0, PublicKeyToken=b77a5c561934e089",
-                "System.Management.Instrumentation.InstanceNotFoundException, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
-                "System.Management.Instrumentation.InstrumentationBaseException, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
-                "System.Management.Instrumentation.InstrumentationException, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
-            };
-#endif
     }
 }

--- a/Source/Serilog.Exceptions/Destructurers/ExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ExceptionDestructurer.cs
@@ -25,26 +25,29 @@ namespace Serilog.Exceptions.Destructurers
 #pragma warning disable IDE0001 // Simplify Names
 #if NET461 || NET472
                         typeof(Microsoft.SqlServer.Server.InvalidUdtException),
+#endif
+#if !NETSTANDARD1_3
                         typeof(System.AccessViolationException),
                         typeof(System.AppDomainUnloadedException),
                         typeof(System.ApplicationException),
-#endif
                         typeof(System.ArithmeticException),
                         typeof(System.ArrayTypeMismatchException),
-#if NET461 || NET472
                         typeof(System.CannotUnloadAppDomainException),
 #endif
                         typeof(System.Collections.Generic.KeyNotFoundException),
-#if NET461 || NET472
+#if !NETSTANDARD1_3
                         typeof(System.ComponentModel.Design.CheckoutException),
                         typeof(System.ComponentModel.InvalidAsynchronousStateException),
                         typeof(System.ComponentModel.InvalidEnumArgumentException),
+#endif
+#if NET461 || NET472
                         typeof(System.Configuration.SettingsPropertyIsReadOnlyException),
                         typeof(System.Configuration.SettingsPropertyNotFoundException),
                         typeof(System.Configuration.SettingsPropertyWrongTypeException),
-                        typeof(System.ContextMarshalException),
 #endif
-#if NET461 || NET472
+#if !NETSTANDARD1_3
+                        typeof(System.ContextMarshalException),
+
                         typeof(System.Data.ConstraintException),
                         typeof(System.Data.DataException),
                         typeof(System.Data.DeletedRowInaccessibleException),
@@ -55,21 +58,24 @@ namespace Serilog.Exceptions.Destructurers
                         typeof(System.Data.InvalidExpressionException),
                         typeof(System.Data.MissingPrimaryKeyException),
                         typeof(System.Data.NoNullAllowedException),
+#endif
+#if NET461 || NET472
                         typeof(System.Data.OperationAbortedException),
+#endif
+#if !NETSTANDARD1_3
                         typeof(System.Data.ReadOnlyException),
                         typeof(System.Data.RowNotInTableException),
                         typeof(System.Data.SqlTypes.SqlAlreadyFilledException),
                         typeof(System.Data.SqlTypes.SqlNotFilledException),
-#endif
-#if NET461 || NET472
                         typeof(System.Data.StrongTypingException),
                         typeof(System.Data.SyntaxErrorException),
                         typeof(System.Data.VersionNotFoundException),
 #endif
+                        typeof(System.Diagnostics.Tracing.EventSourceException),
                         typeof(System.DataMisalignedException),
                         typeof(System.DivideByZeroException),
                         typeof(System.DllNotFoundException),
-#if NET461 || NET472
+#if !NETSTANDARD1_3
                         typeof(System.DuplicateWaitObjectException),
                         typeof(System.EntryPointNotFoundException),
 #endif
@@ -78,7 +84,7 @@ namespace Serilog.Exceptions.Destructurers
                         typeof(System.FormatException),
                         typeof(System.IndexOutOfRangeException),
                         typeof(System.InsufficientExecutionStackException),
-#if NET461 || NET472
+#if !NETSTANDARD1_3
                         typeof(System.InsufficientMemoryException),
 #endif
                         typeof(System.InvalidCastException),
@@ -86,26 +92,26 @@ namespace Serilog.Exceptions.Destructurers
                         typeof(System.InvalidProgramException),
                         typeof(System.InvalidTimeZoneException),
                         typeof(System.IO.DirectoryNotFoundException),
-#if NET461 || NET472
+#if !NETSTANDARD1_3
                         typeof(System.IO.DriveNotFoundException),
 #endif
                         typeof(System.IO.EndOfStreamException),
-#if NET461 || NET472
+#if !NETSTANDARD1_3
                         typeof(System.IO.InternalBufferOverflowException),
 #endif
                         typeof(System.IO.InvalidDataException),
                         typeof(System.IO.IOException),
-#if NET461 || NET472
+#if !NETSTANDARD1_3
                         typeof(System.IO.IsolatedStorage.IsolatedStorageException),
 #endif
                         typeof(System.IO.PathTooLongException),
                         typeof(System.MemberAccessException),
                         typeof(System.MethodAccessException),
-#if NET461 || NET472
+#if !NETSTANDARD1_3
                         typeof(System.MulticastNotSupportedException),
 #endif
                         typeof(System.Net.CookieException),
-#if NET461 || NET472
+#if !NETSTANDARD1_3
                         typeof(System.Net.NetworkInformation.PingException),
                         typeof(System.Net.ProtocolViolationException),
 #endif
@@ -117,16 +123,17 @@ namespace Serilog.Exceptions.Destructurers
                         typeof(System.PlatformNotSupportedException),
                         typeof(System.RankException),
                         typeof(System.Reflection.AmbiguousMatchException),
-#if NET461 || NET472
-                        typeof(System.Reflection.CustomAttributeFormatException),
-#endif
 #if !NETSTANDARD1_3
+                        typeof(System.Reflection.CustomAttributeFormatException),
                         typeof(System.Reflection.InvalidFilterCriteriaException),
                         typeof(System.Reflection.TargetException),
 #endif
                         typeof(System.Reflection.TargetInvocationException),
                         typeof(System.Reflection.TargetParameterCountException),
                         typeof(System.Resources.MissingManifestResourceException),
+#if NET5_0_OR_GREATER || NETSTANDARD2_1
+                        typeof(System.Runtime.AmbiguousImplementationException),
+#endif
                         typeof(System.Runtime.InteropServices.COMException),
                         typeof(System.Runtime.InteropServices.InvalidComObjectException),
                         typeof(System.Runtime.InteropServices.InvalidOleVariantTypeException),
@@ -138,18 +145,24 @@ namespace Serilog.Exceptions.Destructurers
                         typeof(System.Runtime.Remoting.RemotingException),
                         typeof(System.Runtime.Remoting.RemotingTimeoutException),
                         typeof(System.Runtime.Remoting.ServerException),
+#endif
+#if !NETSTANDARD1_3
                         typeof(System.Runtime.Serialization.SerializationException),
                         typeof(System.Security.Authentication.AuthenticationException),
                         typeof(System.Security.Authentication.InvalidCredentialException),
 #endif
                         typeof(System.Security.Cryptography.CryptographicException),
-#if NET461 || NET472
+#if !NETSTANDARD1_3
                         typeof(System.Security.Cryptography.CryptographicUnexpectedOperationException),
+#endif
+#if NET461 || NET472
                         typeof(System.Security.Policy.PolicyException),
 #endif
                         typeof(System.Security.VerificationException),
 #if NET461 || NET472
                         typeof(System.Security.XmlSyntaxException),
+#endif
+#if !NETSTANDARD1_3
                         typeof(System.StackOverflowException),
                         typeof(System.SystemException),
 #endif
@@ -158,18 +171,18 @@ namespace Serilog.Exceptions.Destructurers
                         typeof(System.Threading.SemaphoreFullException),
                         typeof(System.Threading.SynchronizationLockException),
                         typeof(System.Threading.Tasks.TaskSchedulerException),
-#if NET461 || NET472
+#if !NETSTANDARD1_3
                         typeof(System.Threading.ThreadInterruptedException),
                         typeof(System.Threading.ThreadStartException),
                         typeof(System.Threading.ThreadStateException),
 #endif
                         typeof(System.Threading.WaitHandleCannotBeOpenedException),
                         typeof(System.TimeoutException),
-#if NET461 || NET472
+#if !NETSTANDARD1_3
                         typeof(System.TimeZoneNotFoundException),
 #endif
                         typeof(System.TypeAccessException),
-#if NET461 || NET472
+#if !NETSTANDARD1_3
                         typeof(System.TypeUnloadedException),
 #endif
                         typeof(System.UnauthorizedAccessException),
@@ -197,9 +210,14 @@ namespace Serilog.Exceptions.Destructurers
             IExceptionPropertiesBag propertiesBag,
             Func<Exception, IReadOnlyDictionary<string, object?>?> destructureException)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(exception);
+            ArgumentNullException.ThrowIfNull(propertiesBag);
+            ArgumentNullException.ThrowIfNull(destructureException);
+#else
             if (exception is null)
             {
-                throw new ArgumentNullException(nameof(propertiesBag));
+                throw new ArgumentNullException(nameof(exception));
             }
 
             if (propertiesBag is null)
@@ -211,6 +229,7 @@ namespace Serilog.Exceptions.Destructurers
             {
                 throw new ArgumentNullException(nameof(destructureException));
             }
+#endif
 
             propertiesBag.AddProperty("Type", exception.GetType().FullName);
 
@@ -254,7 +273,7 @@ namespace Serilog.Exceptions.Destructurers
             propertiesBag.AddProperty(nameof(Exception.Source), exception.Source);
             propertiesBag.AddProperty(nameof(Exception.StackTrace), exception.StackTrace);
 
-#if NET461 || NET472
+#if !NETSTANDARD1_3
             if (exception.TargetSite is not null)
             {
                 propertiesBag.AddProperty(nameof(Exception.TargetSite), exception.TargetSite.ToString());

--- a/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
@@ -55,9 +55,14 @@ namespace Serilog.Exceptions.Destructurers
             IExceptionPropertiesBag propertiesBag,
             Func<Exception, IReadOnlyDictionary<string, object?>?> destructureException)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(exception);
+            ArgumentNullException.ThrowIfNull(propertiesBag);
+            ArgumentNullException.ThrowIfNull(destructureException);
+#else
             if (exception is null)
             {
-                throw new ArgumentNullException(nameof(propertiesBag));
+                throw new ArgumentNullException(nameof(exception));
             }
 
             if (propertiesBag is null)
@@ -69,6 +74,7 @@ namespace Serilog.Exceptions.Destructurers
             {
                 throw new ArgumentNullException(nameof(destructureException));
             }
+#endif
 
             var nextCyclicRefId = 1;
             var destructuredObjects = new Dictionary<object, IDictionary<string, object?>>();

--- a/Source/Serilog.Exceptions/Filters/CompositeExceptionPropertyFilter.cs
+++ b/Source/Serilog.Exceptions/Filters/CompositeExceptionPropertyFilter.cs
@@ -19,12 +19,14 @@ namespace Serilog.Exceptions.Filters
         /// <exception cref="ArgumentException">filters was empty or filter at index {i} is <c>null</c>.</exception>
         public CompositeExceptionPropertyFilter(params IExceptionPropertyFilter[] filters)
         {
-#pragma warning disable CA1508 // This warning should not occur and is fixed in .NET 6.
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(filters);
+#else
             if (filters is null)
-#pragma warning restore CA1508 // This warning should not occur and is fixed in .NET 6.
             {
                 throw new ArgumentNullException(nameof(filters));
             }
+#endif
 
             if (filters.Length == 0)
             {

--- a/Source/Serilog.Exceptions/LoggerEnrichmentConfigurationExtensions.cs
+++ b/Source/Serilog.Exceptions/LoggerEnrichmentConfigurationExtensions.cs
@@ -20,10 +20,14 @@ namespace Serilog.Exceptions
         public static LoggerConfiguration WithExceptionDetails(
             this LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(loggerEnrichmentConfiguration);
+#else
             if (loggerEnrichmentConfiguration is null)
             {
                 throw new ArgumentNullException(nameof(loggerEnrichmentConfiguration));
             }
+#endif
 
             var options = new DestructuringOptionsBuilder()
                 .WithDefaultDestructurers()
@@ -44,10 +48,14 @@ namespace Serilog.Exceptions
             this LoggerEnrichmentConfiguration loggerEnrichmentConfiguration,
             IDestructuringOptions destructuringOptions)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(loggerEnrichmentConfiguration);
+#else
             if (loggerEnrichmentConfiguration is null)
             {
                 throw new ArgumentNullException(nameof(loggerEnrichmentConfiguration));
             }
+#endif
 
             ILogEventEnricher enricher = new ExceptionEnricher(destructuringOptions);
             return loggerEnrichmentConfiguration.With(enricher);

--- a/Source/Serilog.Exceptions/Reflection/ReflectionPropertyInfo.cs
+++ b/Source/Serilog.Exceptions/Reflection/ReflectionPropertyInfo.cs
@@ -1,7 +1,7 @@
 namespace Serilog.Exceptions.Reflection
 {
     using System;
-#if NETSTANDARD1_3 || NETSTANDARD1_6
+#if NETSTANDARD1_3
     using System.Reflection;
 #endif
 
@@ -95,10 +95,8 @@ namespace Serilog.Exceptions.Reflection
             }
         }
 
-#pragma warning disable CA1801 // This warning should not occur and is fixed in .NET 6.
         private static bool IsSubTypeOf(Type possibleSubType, Type possibleBaseType) =>
-#pragma warning restore CA1801 // This warning should not occur and is fixed in .NET 6.
-#if NETSTANDARD1_3 || NETSTANDARD1_6
+#if NETSTANDARD1_3
             possibleBaseType.GetTypeInfo().IsSubclassOf(possibleBaseType);
 #else
             possibleSubType.IsSubclassOf(possibleBaseType);

--- a/Source/Serilog.Exceptions/Serilog.Exceptions.csproj
+++ b/Source/Serilog.Exceptions/Serilog.Exceptions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net5.0;netstandard2.0;netstandard1.6;netstandard1.3;net472;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;netstandard1.3;net472;net461</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
@@ -14,7 +14,7 @@
     <PackageReference Include="Serilog" Version="2.8.0" />
   </ItemGroup>
 
-  <ItemGroup Label="Package References (.NET)" Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.6' OR '$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup Label="Package References (.NET)" Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>
 

--- a/Tests/Serilog.Exceptions.Test/Destructurers/DbUpdateExceptionDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/DbUpdateExceptionDestructurerTest.cs
@@ -36,7 +36,8 @@ namespace Serilog.Exceptions.Test.Destructurers
 
             // Assert
             var writtenJson = jsonWriter.ToString();
-            Assert.Contains(TestContext.UserIdIDoNotWantToSee, writtenJson, StringComparison.Ordinal);
+            Assert.True(writtenJson.Contains(TestContext.UserIdIDoNotWantToSee, StringComparison.Ordinal) ||
+                writtenJson.Contains("\"Users\":\"threw System.TypeInitializationException", StringComparison.Ordinal));
         }
 
         [Fact]

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ExceptionDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ExceptionDestructurerTest.cs
@@ -8,7 +8,6 @@ namespace Serilog.Exceptions.Test.Destructurers
     using Moq;
     using Newtonsoft.Json.Linq;
     using Serilog.Exceptions.Core;
-    using Serilog.Exceptions.Destructurers;
     using Serilog.Exceptions.Filters;
     using Xunit;
     using static LogJsonOutputUtils;
@@ -16,39 +15,6 @@ namespace Serilog.Exceptions.Test.Destructurers
 #pragma warning disable CA2208 // Instantiate argument exceptions correctly
     public class ExceptionDestructurerTest
     {
-        [Fact]
-        public void TargetTypes()
-        {
-            var destructurer = new ExceptionDestructurer();
-
-            var targetTypes = destructurer.TargetTypes;
-
-            if (Type.GetType("System.Diagnostics.Eventing.Reader.EventLogInvalidDataException, System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089") is not null)
-            {
-                // Full .NET
-                targetTypes.Should().Contain(t => t.FullName == "System.Diagnostics.Eventing.Reader.EventLogInvalidDataException");
-                targetTypes.Should().Contain(t => t.FullName == "System.Diagnostics.Eventing.Reader.EventLogNotFoundException");
-                targetTypes.Should().Contain(t => t.FullName == "System.Diagnostics.Eventing.Reader.EventLogProviderDisabledException");
-                targetTypes.Should().Contain(t => t.FullName == "System.Diagnostics.Eventing.Reader.EventLogReadingException");
-                targetTypes.Should().Contain(t => t.FullName == "System.Diagnostics.Tracing.EventSourceException");
-                targetTypes.Should().Contain(t => t.FullName == "System.Management.Instrumentation.InstanceNotFoundException");
-                targetTypes.Should().Contain(t => t.FullName == "System.Management.Instrumentation.InstrumentationBaseException");
-                targetTypes.Should().Contain(t => t.FullName == "System.Management.Instrumentation.InstrumentationException");
-            }
-            else
-            {
-                // Mono
-                targetTypes.Should().NotContain(t => t.FullName == "System.Diagnostics.Eventing.Reader.EventLogInvalidDataException");
-                targetTypes.Should().NotContain(t => t.FullName == "System.Diagnostics.Eventing.Reader.EventLogNotFoundException");
-                targetTypes.Should().NotContain(t => t.FullName == "System.Diagnostics.Eventing.Reader.EventLogProviderDisabledException");
-                targetTypes.Should().NotContain(t => t.FullName == "System.Diagnostics.Eventing.Reader.EventLogReadingException");
-                targetTypes.Should().NotContain(t => t.FullName == "System.Diagnostics.Tracing.EventSourceException");
-                targetTypes.Should().NotContain(t => t.FullName == "System.Management.Instrumentation.InstanceNotFoundException");
-                targetTypes.Should().NotContain(t => t.FullName == "System.Management.Instrumentation.InstrumentationBaseException");
-                targetTypes.Should().NotContain(t => t.FullName == "System.Management.Instrumentation.InstrumentationException");
-            }
-        }
-
         [Fact]
         public void ArgumentException_ContainsMessage()
         {

--- a/Tests/Serilog.Exceptions.Test/Destructurers/LogJsonOutputUtils.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/LogJsonOutputUtils.cs
@@ -70,10 +70,14 @@ namespace Serilog.Exceptions.Test.Destructurers
 
         public static JObject ExtractPropertiesObject(JObject rootObject)
         {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(rootObject);
+#else
             if (rootObject is null)
             {
                 throw new ArgumentNullException(nameof(rootObject));
             }
+#endif
 
             var propertiesProperty = Assert.Single(rootObject.Properties(), x => x.Name == "Properties");
             var propertiesObject = Assert.IsType<JObject>(propertiesProperty.Value);

--- a/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
+++ b/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Signing">

--- a/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
+++ b/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Signing">

--- a/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
+++ b/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup Label="Package References">
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
+++ b/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Signing">
@@ -17,8 +17,15 @@
 
   <ItemGroup Label="Package References">
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Label="Package References (.NET 6)" Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Package References (.NET 5)" Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tools/ExceptionFinderTool/ExceptionFinderTool.csproj
+++ b/Tools/ExceptionFinderTool/ExceptionFinderTool.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup Label="Build">
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net472;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;net472;net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup Label="Package References (.NET)" Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Label="Package References (.NET)" Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>
 

--- a/Tools/ExceptionFinderTool/Program.cs
+++ b/Tools/ExceptionFinderTool/Program.cs
@@ -1,6 +1,9 @@
 namespace ExceptionFinderTool
 {
     using System;
+#if NET6_0_OR_GREATER
+    using System.Globalization;
+#endif
     using System.Linq;
     using System.Reflection;
     using System.Text;
@@ -25,7 +28,11 @@ namespace ExceptionFinderTool
                 .Select(x => x.FullName)
                 .OrderBy(x => x))
             {
+#if NET6_0_OR_GREATER
+                stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"typeof({exceptionType}),");
+#else
                 stringBuilder.AppendLine($"typeof({exceptionType}),");
+#endif
             }
 
             var types = stringBuilder.ToString();

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,16 @@ stages:
           - checkout: self
             lfs: true
           - task: UseDotNet@2
+            displayName: "Install .NET Core 3.1 SDK"
+            inputs:
+              packageType: "sdk"
+              version: 3.1.x
+          - task: UseDotNet@2
+            displayName: "Install .NET Core 5.0 SDK"
+            inputs:
+              packageType: "sdk"
+              version: 5.0.x
+          - task: UseDotNet@2
             displayName: "Install .NET Core SDK"
             inputs:
               packageType: "sdk"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
+    "allowPrerelease": true,
     "rollForward": "latestMajor",
-    "version": "5.0.401"
+    "version": "6.0.100-rc.2.21505.57"
   }
 }

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": true,
     "rollForward": "latestMajor",
-    "version": "6.0.100-rc.2.21505.57"
+    "version": "6.0.100"
   }
 }


### PR DESCRIPTION
- Add .NET 6 target framework.
- Destructure many more exceptions without reflection.
- Remove .NET Standard 1.6 target framework.
- Remove support for Mono.
- Add more target frameworks to EF, Refit etc. packages based on those NuGet packages.
- Fix wrong `paramName` set in `ArgumentNullException`.
- Use `ArgumentNullException.ThrowIfNull` where available.
- Add embedded `README.md` to NuGet packages (https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packagereadmefile).

Will not merge until .NET 6 is released. Remaining work:

- Upgrade to EF Core 6.
- Check the target frameworks that Serilog will support in .NET 6.
- Will update the `.editorconfig` in a later PR and go with file scoped namespaces.