### PR TITLE
Add RegexMatchTimeoutExceptionDestructurer for RegexMatchTimeoutException

### DIFF
--- a/Source/Serilog.Exceptions/Core/DestructuringOptionsBuilder.cs
+++ b/Source/Serilog.Exceptions/Core/DestructuringOptionsBuilder.cs
@@ -21,6 +21,7 @@ public class DestructuringOptionsBuilder : IDestructuringOptions
         new ArgumentExceptionDestructurer(),
         new ArgumentOutOfRangeExceptionDestructurer(),
         new AggregateExceptionDestructurer(),
+        new RegexMatchTimeoutExceptionDestructurer(),
         new ReflectionTypeLoadExceptionDestructurer(),
         new OperationCanceledExceptionDestructurer(),
         new TaskCanceledExceptionDestructurer(),

--- a/Source/Serilog.Exceptions/Destructurers/RegexMatchTimeoutExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/RegexMatchTimeoutExceptionDestructurer.cs
@@ -1,0 +1,33 @@
+namespace Serilog.Exceptions.Destructurers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text.RegularExpressions;
+    using Serilog.Exceptions.Core;
+
+    /// <summary>
+    /// Destructurer for <see cref="RegexMatchTimeoutException"/>.
+    /// </summary>
+    public class RegexMatchTimeoutExceptionDestructurer
+        : ExceptionDestructurer
+    {
+        /// <inheritdoc cref="IExceptionDestructurer.TargetTypes"/>
+        public override Type[] TargetTypes => new Type[]
+        {
+            typeof(RegexMatchTimeoutException),
+        };
+
+        /// <inheritdoc cref="IExceptionDestructurer.Destructure"/>
+        public override void Destructure(Exception exception, IExceptionPropertiesBag propertiesBag, Func<Exception, IReadOnlyDictionary<string, object?>?> destructureException)
+        {
+            base.Destructure(exception, propertiesBag, destructureException);
+
+#pragma warning disable CA1062 // Validate arguments of public methods
+            var typedException = (RegexMatchTimeoutException)exception;
+            propertiesBag.AddProperty(nameof(RegexMatchTimeoutException.Input), typedException.Input);
+            propertiesBag.AddProperty(nameof(RegexMatchTimeoutException.Pattern), typedException.Pattern);
+            propertiesBag.AddProperty(nameof(RegexMatchTimeoutException.MatchTimeout), typedException.MatchTimeout.ToString("c"));
+#pragma warning restore CA1062 // Validate arguments of public methods
+        }
+    }
+}

--- a/Tests/Serilog.Exceptions.Test/Destructurers/RegexMatchTimeoutExceptionDestructurerTests.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/RegexMatchTimeoutExceptionDestructurerTests.cs
@@ -1,0 +1,30 @@
+namespace Serilog.Exceptions.Test.Destructurers
+{
+    using System;
+    using System.Text.RegularExpressions;
+    using Serilog.Exceptions.Core;
+    using Serilog.Exceptions.Destructurers;
+    using Xunit;
+    using static LogJsonOutputUtils;
+
+    public class RegexMatchTimeoutExceptionDestructurerTests
+    {
+        [Fact]
+        public void RegexMatchTimeoutException_ParamsAttachedAsProperties()
+        {
+            var exception = new RegexMatchTimeoutException("input", "pattern", TimeSpan.FromSeconds(1));
+
+            var optionsBuilder = new DestructuringOptionsBuilder()
+                .WithDestructurers(new IExceptionDestructurer[]
+                {
+                    new RegexMatchTimeoutExceptionDestructurer(),
+                });
+
+            var loggedExceptionDetails = ExtractExceptionDetails(LogAndDestructureException(exception, optionsBuilder));
+
+            Assert_ContainsPropertyWithValue(loggedExceptionDetails, nameof(RegexMatchTimeoutException.Input), exception.Input);
+            Assert_ContainsPropertyWithValue(loggedExceptionDetails, nameof(RegexMatchTimeoutException.Pattern), exception.Pattern);
+            Assert_ContainsPropertyWithValue(loggedExceptionDetails, nameof(RegexMatchTimeoutException.MatchTimeout), exception.MatchTimeout.ToString("c"));
+        }
+    }
+}


### PR DESCRIPTION
As per https://github.com/RehanSaeed/Serilog.Exceptions/issues/418, adding a custom destructurer for RegexMatchTimeoutException.

After the fail that was PR #456 have now made sure that the commit is applied to main instead of master...