### PR TITLE
Upgrade to .NET 7 and C# 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           dotnet-version: |
             3.1.x
-            5.0.x
+            6.0.x
           global-json-file: "./global.json"
       - name: "Dotnet Tool Restore"
         run: dotnet tool restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,7 @@ jobs:
           path: "./Artefacts"
       - name: "Publish Test Summary"
         uses: test-summary/action@v2
+        if: always()
         with:
           paths: "./Artefacts/*/*.xml"
 

--- a/Benchmarks/Serilog.Exceptions.Benchmark/BenchmarkExceptionDestructurer.cs
+++ b/Benchmarks/Serilog.Exceptions.Benchmark/BenchmarkExceptionDestructurer.cs
@@ -22,7 +22,6 @@ public class BenchmarkExceptionDestructurer : ExceptionDestructurer
     {
         base.Destructure(exception, propertiesBag, destructureException);
 
-#pragma warning disable CA1062 // Validate arguments of public methods
         var benchmarkException = (BenchmarkException)exception;
         propertiesBag.AddProperty("ParamString", benchmarkException.ParamString);
         propertiesBag.AddProperty("ParamInt", benchmarkException.ParamInt);
@@ -31,6 +30,5 @@ public class BenchmarkExceptionDestructurer : ExceptionDestructurer
                 { "X", benchmarkException.Point?.X },
                 { "Y", benchmarkException.Point?.Y },
             });
-#pragma warning restore CA1062 // Validate arguments of public methods
     }
 }

--- a/Benchmarks/Serilog.Exceptions.Benchmark/DestructuringBenchmark.cs
+++ b/Benchmarks/Serilog.Exceptions.Benchmark/DestructuringBenchmark.cs
@@ -13,6 +13,7 @@ using Serilog.Exceptions.Destructurers;
 [HtmlExporter]
 [CsvMeasurementsExporter]
 [RPlotExporter]
+[SimpleJob(RuntimeMoniker.Net70)]
 [SimpleJob(RuntimeMoniker.Net60)]
 [SimpleJob(RuntimeMoniker.Net472)]
 public class DestructuringBenchmark

--- a/Benchmarks/Serilog.Exceptions.Benchmark/Serilog.Exceptions.Benchmark.csproj
+++ b/Benchmarks/Serilog.Exceptions.Benchmark/Serilog.Exceptions.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup Label="Build">
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -18,11 +18,11 @@
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
   </ItemGroup>
 
-  <ItemGroup Label="Package References (.NET)" Condition=" '$(TargetFramework)' == 'net6.0' ">
+  <ItemGroup Label="Package References (.NET)" Condition="'$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>
 
-  <ItemGroup Label="References (.NET Framework)" Condition=" '$(TargetFramework)' == 'net472' ">
+  <ItemGroup Label="References (.NET Framework)" Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,9 +25,9 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <GlobalPackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.27" />
-    <GlobalPackageReference Include="MinVer" Version="4.2.0" />
-    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="All" Version="17.4.27" />
+    <PackageReference Include="MinVer" PrivateAssets="All" Version="4.2.0" />
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.2.0-beta.435" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup Label="Build">
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup Label="Build">
-    <LangVersion>preview</LangVersion>
+    <LangVersion>latest</LangVersion>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,10 +25,9 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="All" Version="17.4.27" />
-    <PackageReference Include="MinVer" PrivateAssets="All" Version="4.2.0" />
-    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.2.0-beta.435" />
+    <GlobalPackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.4.27" />
+    <GlobalPackageReference Include="MinVer" Version="4.2.0" />
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,8 +5,8 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <AnalysisLevel>latest</AnalysisLevel>
-    <Nullable>enable</Nullable>
     <NeutralLanguage>en-GB</NeutralLanguage>
+    <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/Source/Serilog.Exceptions.EntityFrameworkCore/Destructurers/DbUpdateExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions.EntityFrameworkCore/Destructurers/DbUpdateExceptionDestructurer.cs
@@ -24,7 +24,6 @@ public class DbUpdateExceptionDestructurer : ExceptionDestructurer
     {
         base.Destructure(exception, propertiesBag, destructureException);
 
-#pragma warning disable CA1062 // Validate arguments of public methods
         var dbUpdateException = (DbUpdateException)exception;
         var entriesValue = dbUpdateException.Entries?
             .Select(
@@ -43,6 +42,5 @@ public class DbUpdateExceptionDestructurer : ExceptionDestructurer
                 })
             .ToList();
         propertiesBag.AddProperty(nameof(DbUpdateException.Entries), entriesValue);
-#pragma warning restore CA1062 // Validate arguments of public methods
     }
 }

--- a/Source/Serilog.Exceptions.EntityFrameworkCore/Serilog.Exceptions.EntityFrameworkCore.csproj
+++ b/Source/Serilog.Exceptions.EntityFrameworkCore/Serilog.Exceptions.EntityFrameworkCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
@@ -14,12 +14,12 @@
     <ProjectReference Include="..\Serilog.Exceptions\Serilog.Exceptions.csproj" />
   </ItemGroup>
 
-  <ItemGroup Label="Package References (.NET 6)" Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
+  <ItemGroup Label="Package References (.NET 7)" Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0-preview.7.22376.2" />
   </ItemGroup>
 
-  <ItemGroup Label="Package References (.NET 5)" Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
+  <ItemGroup Label="Package References (.NET 6)" Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="Package References (NetStandard 2)" Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/Source/Serilog.Exceptions.EntityFrameworkCore/Serilog.Exceptions.EntityFrameworkCore.csproj
+++ b/Source/Serilog.Exceptions.EntityFrameworkCore/Serilog.Exceptions.EntityFrameworkCore.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References (.NET 7)" Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0-preview.7.22376.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="Package References (.NET 6)" Condition="'$(TargetFramework)' == 'net6.0'">

--- a/Source/Serilog.Exceptions.Grpc/Destructurers/RpcExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions.Grpc/Destructurers/RpcExceptionDestructurer.cs
@@ -25,7 +25,6 @@ public class RpcExceptionDestructurer : ExceptionDestructurer
 
         var rpcException = (RpcException)exception;
 
-#pragma warning disable CA1062 // Validate arguments of public methods
         propertiesBag.AddProperty(nameof(RpcException.Status.StatusCode), rpcException.Status.StatusCode);
         propertiesBag.AddProperty(nameof(RpcException.Status.Detail), rpcException.Status.Detail);
 
@@ -38,6 +37,5 @@ public class RpcExceptionDestructurer : ExceptionDestructurer
 
             propertiesBag.AddProperty($"{nameof(RpcException.Trailers)}.{trailer.Key}", trailer.Value);
         }
-#pragma warning restore CA1062 // Validate arguments of public methods
     }
 }

--- a/Source/Serilog.Exceptions.MsSqlServer/Destructurers/SqlExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions.MsSqlServer/Destructurers/SqlExceptionDestructurer.cs
@@ -24,7 +24,6 @@ public class SqlExceptionDestructurer : ExceptionDestructurer
     {
         base.Destructure(exception, propertiesBag, destructureException);
 
-#pragma warning disable CA1062 // Validate arguments of public methods
         var sqlException = (SqlException)exception;
         propertiesBag.AddProperty(nameof(SqlException.ClientConnectionId), sqlException.ClientConnectionId);
         propertiesBag.AddProperty(nameof(SqlException.Class), sqlException.Class);
@@ -33,6 +32,5 @@ public class SqlExceptionDestructurer : ExceptionDestructurer
         propertiesBag.AddProperty(nameof(SqlException.Server), sqlException.Server);
         propertiesBag.AddProperty(nameof(SqlException.State), sqlException.State);
         propertiesBag.AddProperty(nameof(SqlException.Errors), sqlException.Errors.Cast<SqlError>().ToArray());
-#pragma warning restore CA1062 // Validate arguments of public methods
     }
 }

--- a/Source/Serilog.Exceptions.MsSqlServer/Serilog.Exceptions.MsSqlServer.csproj
+++ b/Source/Serilog.Exceptions.MsSqlServer/Serilog.Exceptions.MsSqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;net472;net461</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">

--- a/Source/Serilog.Exceptions.Refit/Destructurers/ApiExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions.Refit/Destructurers/ApiExceptionDestructurer.cs
@@ -62,7 +62,6 @@ public class ApiExceptionDestructurer : ExceptionDestructurer
 #endif
         }
 
-#pragma warning disable CA1062 // Validate arguments of public methods
         var apiException = (ApiException)exception;
         if (this.destructureHttpContent)
         {
@@ -71,6 +70,5 @@ public class ApiExceptionDestructurer : ExceptionDestructurer
 
         propertiesBag.AddProperty(nameof(ApiException.Uri), apiException.Uri);
         propertiesBag.AddProperty(nameof(ApiException.StatusCode), apiException.StatusCode);
-#pragma warning restore CA1062 // Validate arguments of public methods
     }
 }

--- a/Source/Serilog.Exceptions.Refit/Serilog.Exceptions.Refit.csproj
+++ b/Source/Serilog.Exceptions.Refit/Serilog.Exceptions.Refit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;net472;net461</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
@@ -9,7 +9,7 @@
     <Description>Log exception details and custom properties that are not output in Exception.ToString(). Contains custom destructurers for Refit exceptions.</Description>
     <PackageTags>Serilog;Exception;Log;Logging;Detail;Details;Refit</PackageTags>
   </PropertyGroup>
- 
+
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Source\Serilog.Exceptions\Serilog.Exceptions.csproj" />
   </ItemGroup>
@@ -17,5 +17,5 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="Refit" Version="6.3.2" />
   </ItemGroup>
-  
+
 </Project>

--- a/Source/Serilog.Exceptions.Refit/Serilog.Exceptions.Refit.csproj
+++ b/Source/Serilog.Exceptions.Refit/Serilog.Exceptions.Refit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">

--- a/Source/Serilog.Exceptions.SqlServer/Destructurers/SqlExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions.SqlServer/Destructurers/SqlExceptionDestructurer.cs
@@ -24,7 +24,6 @@ public class SqlExceptionDestructurer : ExceptionDestructurer
     {
         base.Destructure(exception, propertiesBag, destructureException);
 
-#pragma warning disable CA1062 // Validate arguments of public methods
         var sqlException = (SqlException)exception;
         propertiesBag.AddProperty(nameof(SqlException.ClientConnectionId), sqlException.ClientConnectionId);
         propertiesBag.AddProperty(nameof(SqlException.Class), sqlException.Class);
@@ -33,6 +32,5 @@ public class SqlExceptionDestructurer : ExceptionDestructurer
         propertiesBag.AddProperty(nameof(SqlException.Server), sqlException.Server);
         propertiesBag.AddProperty(nameof(SqlException.State), sqlException.State);
         propertiesBag.AddProperty(nameof(SqlException.Errors), sqlException.Errors.Cast<SqlError>().ToArray());
-#pragma warning restore CA1062 // Validate arguments of public methods
     }
 }

--- a/Source/Serilog.Exceptions.SqlServer/Serilog.Exceptions.SqlServer.csproj
+++ b/Source/Serilog.Exceptions.SqlServer/Serilog.Exceptions.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;netstandard1.3;net461</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;netstandard1.3;net462</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">

--- a/Source/Serilog.Exceptions.SqlServer/Serilog.Exceptions.SqlServer.csproj
+++ b/Source/Serilog.Exceptions.SqlServer/Serilog.Exceptions.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;netstandard1.3;net472;net461</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;netstandard1.3;net461</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\..\Source\Serilog.Exceptions\Serilog.Exceptions.csproj" />
   </ItemGroup>
 
-  <ItemGroup Label="Package References (.NET)" Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.3'">
+  <ItemGroup Label="Package References (.NET)" Condition="'$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
   </ItemGroup>
 

--- a/Source/Serilog.Exceptions/Core/DestructuringOptionsBuilder.cs
+++ b/Source/Serilog.Exceptions/Core/DestructuringOptionsBuilder.cs
@@ -34,7 +34,7 @@ public class DestructuringOptionsBuilder : IDestructuringOptions
     /// </summary>
     public static readonly IExceptionPropertyFilter IgnoreStackTraceAndTargetSiteExceptionFilter =
 
-#if NET461
+#if NET462
             new IgnorePropertyByNameExceptionFilter(
             nameof(Exception.StackTrace),
             nameof(Exception.TargetSite));

--- a/Source/Serilog.Exceptions/Core/DestructuringOptionsBuilder.cs
+++ b/Source/Serilog.Exceptions/Core/DestructuringOptionsBuilder.cs
@@ -34,7 +34,7 @@ public class DestructuringOptionsBuilder : IDestructuringOptions
     /// </summary>
     public static readonly IExceptionPropertyFilter IgnoreStackTraceAndTargetSiteExceptionFilter =
 
-#if NET461 || NET472
+#if NET461
             new IgnorePropertyByNameExceptionFilter(
             nameof(Exception.StackTrace),
             nameof(Exception.TargetSite));

--- a/Source/Serilog.Exceptions/Destructurers/AggregateExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/AggregateExceptionDestructurer.cs
@@ -21,11 +21,9 @@ public class AggregateExceptionDestructurer : ExceptionDestructurer
     {
         base.Destructure(exception, propertiesBag, destructureException);
 
-#pragma warning disable CA1062 // Validate arguments of public methods
         var aggregateException = (AggregateException)exception;
         propertiesBag.AddProperty(
             nameof(AggregateException.InnerExceptions),
             aggregateException.InnerExceptions.Select(destructureException).ToList());
-#pragma warning restore CA1062 // Validate arguments of public methods
     }
 }

--- a/Source/Serilog.Exceptions/Destructurers/ArgumentExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ArgumentExceptionDestructurer.cs
@@ -24,9 +24,7 @@ public class ArgumentExceptionDestructurer : ExceptionDestructurer
     {
         base.Destructure(exception, propertiesBag, destructureException);
 
-#pragma warning disable CA1062 // Validate arguments of public methods
         var argumentException = (ArgumentException)exception;
         propertiesBag.AddProperty(nameof(ArgumentException.ParamName), argumentException.ParamName);
-#pragma warning restore CA1062 // Validate arguments of public methods
     }
 }

--- a/Source/Serilog.Exceptions/Destructurers/ArgumentOutOfRangeExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ArgumentOutOfRangeExceptionDestructurer.cs
@@ -23,9 +23,7 @@ public class ArgumentOutOfRangeExceptionDestructurer : ArgumentExceptionDestruct
     {
         base.Destructure(exception, propertiesBag, destructureException);
 
-#pragma warning disable CA1062 // Validate arguments of public methods
         var argumentException = (ArgumentOutOfRangeException)exception;
         propertiesBag.AddProperty(nameof(ArgumentOutOfRangeException.ActualValue), argumentException.ActualValue);
-#pragma warning restore CA1062 // Validate arguments of public methods
     }
 }

--- a/Source/Serilog.Exceptions/Destructurers/ExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ExceptionDestructurer.cs
@@ -18,7 +18,7 @@ public class ExceptionDestructurer : IExceptionDestructurer
             var targetTypes = new List<Type>
                     {
 #pragma warning disable IDE0001 // Simplify Names
-#if NET461
+#if NET462
                         typeof(Microsoft.SqlServer.Server.InvalidUdtException),
 #endif
 #if !NETSTANDARD1_3
@@ -35,7 +35,7 @@ public class ExceptionDestructurer : IExceptionDestructurer
                         typeof(System.ComponentModel.InvalidAsynchronousStateException),
                         typeof(System.ComponentModel.InvalidEnumArgumentException),
 #endif
-#if NET461
+#if NET462
                         typeof(System.Configuration.SettingsPropertyIsReadOnlyException),
                         typeof(System.Configuration.SettingsPropertyNotFoundException),
                         typeof(System.Configuration.SettingsPropertyWrongTypeException),
@@ -54,7 +54,7 @@ public class ExceptionDestructurer : IExceptionDestructurer
                         typeof(System.Data.MissingPrimaryKeyException),
                         typeof(System.Data.NoNullAllowedException),
 #endif
-#if NET461
+#if NET462
                         typeof(System.Data.OperationAbortedException),
 #endif
 #if !NETSTANDARD1_3
@@ -66,7 +66,7 @@ public class ExceptionDestructurer : IExceptionDestructurer
                         typeof(System.Data.SyntaxErrorException),
                         typeof(System.Data.VersionNotFoundException),
 #endif
-#if NET461
+#if NET462
                         typeof(System.Diagnostics.Eventing.Reader.EventLogInvalidDataException),
                         typeof(System.Diagnostics.Eventing.Reader.EventLogNotFoundException),
                         typeof(System.Diagnostics.Eventing.Reader.EventLogProviderDisabledException),
@@ -106,7 +106,7 @@ public class ExceptionDestructurer : IExceptionDestructurer
                         typeof(System.IO.IsolatedStorage.IsolatedStorageException),
 #endif
                         typeof(System.IO.PathTooLongException),
-#if NET461
+#if NET462
                         typeof(System.Management.Instrumentation.InstanceNotFoundException),
                         typeof(System.Management.Instrumentation.InstrumentationBaseException),
                         typeof(System.Management.Instrumentation.InstrumentationException),
@@ -147,7 +147,7 @@ public class ExceptionDestructurer : IExceptionDestructurer
                         typeof(System.Runtime.InteropServices.SafeArrayRankMismatchException),
                         typeof(System.Runtime.InteropServices.SafeArrayTypeMismatchException),
                         typeof(System.Runtime.InteropServices.SEHException),
-#if NET461
+#if NET462
                         typeof(System.Runtime.Remoting.RemotingException),
                         typeof(System.Runtime.Remoting.RemotingTimeoutException),
                         typeof(System.Runtime.Remoting.ServerException),
@@ -161,11 +161,11 @@ public class ExceptionDestructurer : IExceptionDestructurer
 #if !NETSTANDARD1_3
                         typeof(System.Security.Cryptography.CryptographicUnexpectedOperationException),
 #endif
-#if NET461
+#if NET462
                         typeof(System.Security.Policy.PolicyException),
 #endif
                         typeof(System.Security.VerificationException),
-#if NET461
+#if NET462
                         typeof(System.Security.XmlSyntaxException),
 #endif
 #if !NETSTANDARD1_3

--- a/Source/Serilog.Exceptions/Destructurers/ExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ExceptionDestructurer.cs
@@ -20,7 +20,7 @@ public class ExceptionDestructurer : IExceptionDestructurer
             var targetTypes = new List<Type>
                     {
 #pragma warning disable IDE0001 // Simplify Names
-#if NET461 || NET472
+#if NET461
                         typeof(Microsoft.SqlServer.Server.InvalidUdtException),
 #endif
 #if !NETSTANDARD1_3
@@ -37,7 +37,7 @@ public class ExceptionDestructurer : IExceptionDestructurer
                         typeof(System.ComponentModel.InvalidAsynchronousStateException),
                         typeof(System.ComponentModel.InvalidEnumArgumentException),
 #endif
-#if NET461 || NET472
+#if NET461
                         typeof(System.Configuration.SettingsPropertyIsReadOnlyException),
                         typeof(System.Configuration.SettingsPropertyNotFoundException),
                         typeof(System.Configuration.SettingsPropertyWrongTypeException),
@@ -56,7 +56,7 @@ public class ExceptionDestructurer : IExceptionDestructurer
                         typeof(System.Data.MissingPrimaryKeyException),
                         typeof(System.Data.NoNullAllowedException),
 #endif
-#if NET461 || NET472
+#if NET461
                         typeof(System.Data.OperationAbortedException),
 #endif
 #if !NETSTANDARD1_3
@@ -68,7 +68,7 @@ public class ExceptionDestructurer : IExceptionDestructurer
                         typeof(System.Data.SyntaxErrorException),
                         typeof(System.Data.VersionNotFoundException),
 #endif
-#if NET461 || NET472
+#if NET461
                         typeof(System.Diagnostics.Eventing.Reader.EventLogInvalidDataException),
                         typeof(System.Diagnostics.Eventing.Reader.EventLogNotFoundException),
                         typeof(System.Diagnostics.Eventing.Reader.EventLogProviderDisabledException),
@@ -108,7 +108,7 @@ public class ExceptionDestructurer : IExceptionDestructurer
                         typeof(System.IO.IsolatedStorage.IsolatedStorageException),
 #endif
                         typeof(System.IO.PathTooLongException),
-#if NET461 || NET472
+#if NET461
                         typeof(System.Management.Instrumentation.InstanceNotFoundException),
                         typeof(System.Management.Instrumentation.InstrumentationBaseException),
                         typeof(System.Management.Instrumentation.InstrumentationException),
@@ -149,7 +149,7 @@ public class ExceptionDestructurer : IExceptionDestructurer
                         typeof(System.Runtime.InteropServices.SafeArrayRankMismatchException),
                         typeof(System.Runtime.InteropServices.SafeArrayTypeMismatchException),
                         typeof(System.Runtime.InteropServices.SEHException),
-#if NET461 || NET472
+#if NET461
                         typeof(System.Runtime.Remoting.RemotingException),
                         typeof(System.Runtime.Remoting.RemotingTimeoutException),
                         typeof(System.Runtime.Remoting.ServerException),
@@ -163,11 +163,11 @@ public class ExceptionDestructurer : IExceptionDestructurer
 #if !NETSTANDARD1_3
                         typeof(System.Security.Cryptography.CryptographicUnexpectedOperationException),
 #endif
-#if NET461 || NET472
+#if NET461
                         typeof(System.Security.Policy.PolicyException),
 #endif
                         typeof(System.Security.VerificationException),
-#if NET461 || NET472
+#if NET461
                         typeof(System.Security.XmlSyntaxException),
 #endif
 #if !NETSTANDARD1_3

--- a/Source/Serilog.Exceptions/Destructurers/ExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ExceptionDestructurer.cs
@@ -11,9 +11,7 @@ using Serilog.Exceptions.Core;
 public class ExceptionDestructurer : IExceptionDestructurer
 {
     /// <inheritdoc cref="IExceptionDestructurer.TargetTypes"/>
-#pragma warning disable CA1819 // Properties should not return arrays
     public virtual Type[] TargetTypes
-#pragma warning restore CA1819 // Properties should not return arrays
     {
         get
         {

--- a/Source/Serilog.Exceptions/Destructurers/IExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/IExceptionDestructurer.cs
@@ -13,9 +13,7 @@ public interface IExceptionDestructurer
     /// <summary>
     /// Gets a collection of exception types that the destructurer can handle.
     /// </summary>
-#pragma warning disable CA1819 // Properties should not return arrays
     Type[] TargetTypes { get; }
-#pragma warning restore CA1819 // Properties should not return arrays
 
     /// <summary>
     /// Destructures given <paramref name="exception"/>. It's properties are to be put in

--- a/Source/Serilog.Exceptions/Destructurers/OperationCanceledExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/OperationCanceledExceptionDestructurer.cs
@@ -29,12 +29,10 @@ public class OperationCanceledExceptionDestructurer : ExceptionDestructurer
     {
         base.Destructure(exception, propertiesBag, destructureException);
 
-#pragma warning disable CA1062 // Validate arguments of public methods
         var operationCancelledException = (OperationCanceledException)exception;
         propertiesBag.AddProperty(
             nameof(OperationCanceledException.CancellationToken),
             DestructureCancellationToken(operationCancelledException.CancellationToken));
-#pragma warning restore CA1062 // Validate arguments of public methods
     }
 
     /// <summary>

--- a/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
@@ -207,7 +207,7 @@ public class ReflectionBasedDestructurer : IExceptionDestructurer
             return this.DestructureValueDictionary(dictionary, level, destructuredObjects, ref nextCyclicRefId);
         }
 
-        if (value is IQueryable queryable)
+        if (value is IQueryable)
         {
             return IQueryableDestructureSkippedMessage;
         }

--- a/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ReflectionBasedDestructurer.cs
@@ -45,9 +45,7 @@ public class ReflectionBasedDestructurer : IExceptionDestructurer
     }
 
     /// <inheritdoc cref="IExceptionDestructurer.TargetTypes"/>
-#pragma warning disable CA1819 // Properties should not return arrays
     public Type[] TargetTypes => new[] { typeof(Exception) };
-#pragma warning restore CA1819 // Properties should not return arrays
 
     /// <inheritdoc cref="IExceptionDestructurer.Destructure"/>
     public void Destructure(
@@ -168,12 +166,10 @@ public class ReflectionBasedDestructurer : IExceptionDestructurer
                     addPropertyAction(property.Name, $"threw {innerException.GetType().FullName}: {innerException.Message}");
                 }
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception exception)
             {
                 addPropertyAction(property.Name, $"threw {exception.GetType().FullName}: {exception.Message}");
             }
-#pragma warning restore CA1031 // Do not catch general exception types
         }
     }
 
@@ -333,12 +329,10 @@ public class ReflectionBasedDestructurer : IExceptionDestructurer
                     values.Add(property.Name, $"threw {innerException.GetType().FullName}: {innerException.Message}");
                 }
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception exception)
             {
                 values.Add(property.Name, $"threw {exception.GetType().FullName}: {exception.Message}");
             }
-#pragma warning restore CA1031 // Do not catch general exception types
         }
 
         return values;

--- a/Source/Serilog.Exceptions/Destructurers/ReflectionTypeLoadExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/ReflectionTypeLoadExceptionDestructurer.cs
@@ -21,7 +21,6 @@ public class ReflectionTypeLoadExceptionDestructurer : ExceptionDestructurer
     {
         base.Destructure(exception, propertiesBag, destructureException);
 
-#pragma warning disable CA1062 // Validate arguments of public methods
         var reflectionTypeLoadException = (ReflectionTypeLoadException)exception;
         if (reflectionTypeLoadException.LoaderExceptions is not null)
         {
@@ -29,7 +28,6 @@ public class ReflectionTypeLoadExceptionDestructurer : ExceptionDestructurer
                 nameof(ReflectionTypeLoadException.LoaderExceptions),
                 GetLoaderExceptionsValue(reflectionTypeLoadException.LoaderExceptions, destructureException));
         }
-#pragma warning restore CA1062 // Validate arguments of public methods
     }
 
     private static List<IReadOnlyDictionary<string, object?>> GetLoaderExceptionsValue(

--- a/Source/Serilog.Exceptions/Destructurers/RegexMatchTimeoutExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/RegexMatchTimeoutExceptionDestructurer.cs
@@ -21,11 +21,9 @@ public class RegexMatchTimeoutExceptionDestructurer : ExceptionDestructurer
     {
         base.Destructure(exception, propertiesBag, destructureException);
 
-#pragma warning disable CA1062 // Validate arguments of public methods
         var typedException = (RegexMatchTimeoutException)exception;
         propertiesBag.AddProperty(nameof(RegexMatchTimeoutException.Input), typedException.Input);
         propertiesBag.AddProperty(nameof(RegexMatchTimeoutException.Pattern), typedException.Pattern);
         propertiesBag.AddProperty(nameof(RegexMatchTimeoutException.MatchTimeout), typedException.MatchTimeout.ToString("c"));
-#pragma warning restore CA1062 // Validate arguments of public methods
     }
 }

--- a/Source/Serilog.Exceptions/Destructurers/SocketExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/SocketExceptionDestructurer.cs
@@ -77,13 +77,11 @@ public class SocketExceptionDestructurer : ExceptionDestructurer
     {
         base.Destructure(exception, propertiesBag, destructureException);
 
-#pragma warning disable CA1062 // Validate arguments of public methods
         var socketException = (SocketException)exception;
         propertiesBag.AddProperty(nameof(SocketException.SocketErrorCode), socketException.SocketErrorCode);
         if (SocketErrorDocumentationBySocketError.TryGetValue(socketException.SocketErrorCode, out var documentation))
         {
             propertiesBag.AddProperty(nameof(SocketException.SocketErrorCode) + "Message", documentation);
         }
-#pragma warning restore CA1062 // Validate arguments of public methods
     }
 }

--- a/Source/Serilog.Exceptions/Destructurers/TaskCanceledExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions/Destructurers/TaskCanceledExceptionDestructurer.cs
@@ -24,14 +24,12 @@ public class TaskCanceledExceptionDestructurer : OperationCanceledExceptionDestr
         IExceptionPropertiesBag propertiesBag,
         Func<Exception, IReadOnlyDictionary<string, object?>?> destructureException)
     {
-#pragma warning disable CA1062 // Validate arguments of public methods
         base.Destructure(exception, propertiesBag, destructureException);
 
         var taskCancelledException = (TaskCanceledException)exception;
         propertiesBag.AddProperty(
             nameof(TaskCanceledException.Task),
             DestructureTask(taskCancelledException.Task, destructureException));
-#pragma warning restore CA1062 // Validate arguments of public methods
     }
 
     /// <summary>

--- a/Source/Serilog.Exceptions/Serilog.Exceptions.csproj
+++ b/Source/Serilog.Exceptions/Serilog.Exceptions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;netstandard1.3;net472;net461</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;netstandard1.3;net461</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
   </ItemGroup>
 
-  <ItemGroup Label="Package References (.NET)" Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.3'">
+  <ItemGroup Label="Package References (.NET)" Condition="'$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>
 

--- a/Source/Serilog.Exceptions/Serilog.Exceptions.csproj
+++ b/Source/Serilog.Exceptions/Serilog.Exceptions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;netstandard1.3;net461</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;netstandard1.3;net462</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">

--- a/Tests/Serilog.Exceptions.Test/Destructurers/AggregateExceptionDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/AggregateExceptionDestructurerTest.cs
@@ -10,10 +10,8 @@ public class AggregateExceptionDestructurerTest
     [Fact]
     public void AggregateException_WithTwoArgumentExceptions_TheyAreSerializedInInnerExceptionsProperty()
     {
-#pragma warning disable CA2208 // Instantiate argument exceptions correctly
         var argumentException1 = new ArgumentException("MSG1", "testParamName1");
         var argumentException2 = new ArgumentException("MSG1", "testParamName2");
-#pragma warning restore CA2208 // Instantiate argument exceptions correctly
         var aggregateException = new AggregateException(argumentException1, argumentException2);
 
         var rootObject = LogAndDestructureException(aggregateException);

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ArgumentExceptionDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ArgumentExceptionDestructurerTest.cs
@@ -9,9 +9,7 @@ public class ArgumentExceptionDestructurerTest
     [Fact]
     public void ArgumentException_ParamNameIsAttachedAsProperty()
     {
-#pragma warning disable CA2208 // Instantiate argument exceptions correctly
         var argumentException = new ArgumentException("MSG", "testParamName");
-#pragma warning restore CA2208 // Instantiate argument exceptions correctly
         Test_LoggedExceptionContainsProperty(argumentException, "ParamName", "testParamName");
     }
 }

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ArgumentNullExceptionDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ArgumentNullExceptionDestructurerTest.cs
@@ -9,9 +9,7 @@ public class ArgumentNullExceptionDestructurerTest
     [Fact]
     public void ArgumentNullException_ParamNameIsAttachedAsProperty()
     {
-#pragma warning disable CA2208 // Instantiate argument exceptions correctly
         var argumentException = new ArgumentNullException("testParamName", "MSG");
-#pragma warning restore CA2208 // Instantiate argument exceptions correctly
         Test_LoggedExceptionContainsProperty(argumentException, "ParamName", "testParamName");
     }
 }

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ArgumentOutOfRangeExceptionDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ArgumentOutOfRangeExceptionDestructurerTest.cs
@@ -9,18 +9,14 @@ public class ArgumentOutOfRangeExceptionDestructurerTest
     [Fact]
     public void ArgumentOfOutRangeException_ParamNameIsAttachedAsProperty()
     {
-#pragma warning disable CA2208 // Instantiate argument exceptions correctly
         var argumentException = new ArgumentOutOfRangeException("testParamName");
-#pragma warning restore CA2208 // Instantiate argument exceptions correctly
         Test_LoggedExceptionContainsProperty(argumentException, "ParamName", "testParamName");
     }
 
     [Fact]
     public void ArgumentOfOutRangeException_ActualValueIsAttachedAsProperty()
     {
-#pragma warning disable CA2208 // Instantiate argument exceptions correctly
         var argumentException = new ArgumentOutOfRangeException("testParamName", "ACTUAL_VALUE", "MSG");
-#pragma warning restore CA2208 // Instantiate argument exceptions correctly
         Test_LoggedExceptionContainsProperty(argumentException, "ActualValue", "ACTUAL_VALUE");
     }
 }

--- a/Tests/Serilog.Exceptions.Test/Destructurers/DbUpdateExceptionDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/DbUpdateExceptionDestructurerTest.cs
@@ -16,7 +16,6 @@ public class DbUpdateExceptionDestructurerTest
     [Fact]
     public void WithoutDbUpdateExceptionDestructurerShouldLogDbValues()
     {
-        // Arrange
         var jsonWriter = new StringWriter();
         ILogger logger = new LoggerConfiguration()
             .Enrich.WithExceptionDetails(new DestructuringOptionsBuilder().WithDefaultDestructurers())
@@ -31,10 +30,8 @@ public class DbUpdateExceptionDestructurerTest
             UserId = Guid.NewGuid().ToString(),
         });
 
-        // Act
         logger.Error(new TestDbUpdateException("DbUpdate Error", entry), "Error");
 
-        // Assert
         var writtenJson = jsonWriter.ToString();
         Assert.True(writtenJson.Contains(TestContext.UserIdIDoNotWantToSee, StringComparison.Ordinal) ||
             writtenJson.Contains("\"Users\":\"threw System.TypeInitializationException", StringComparison.Ordinal));
@@ -43,7 +40,6 @@ public class DbUpdateExceptionDestructurerTest
     [Fact]
     public void WithDbUpdateExceptionDestructurerShouldNotLogDbValues()
     {
-        // Arrange
         var jsonWriter = new StringWriter();
         ILogger logger = new LoggerConfiguration()
             .Enrich.WithExceptionDetails(new DestructuringOptionsBuilder().WithDefaultDestructurers().WithDestructurers(new[] { new TestDbUpdateExceptionDestructurer() }))
@@ -58,10 +54,8 @@ public class DbUpdateExceptionDestructurerTest
             UserId = Guid.NewGuid().ToString(),
         });
 
-        // Act
         logger.Error(new TestDbUpdateException("DbUpdate Error", entry), "Error");
 
-        // Assert
         var writtenJson = jsonWriter.ToString();
         Assert.DoesNotContain(TestContext.UserIdIDoNotWantToSee, writtenJson, StringComparison.Ordinal);
     }

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ExceptionDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ExceptionDestructurerTest.cs
@@ -202,6 +202,8 @@ public class ExceptionDestructurerTest
 
         public DbContext Context { get; }
     }
+#pragma warning restore CS3003 // Type is not CLS-compliant
+#pragma warning restore CS3001 // Argument type is not CLS-compliant
 
     private class ExceptionDbContext : DbContext
     {

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ExceptionDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ExceptionDestructurerTest.cs
@@ -11,7 +11,6 @@ using Serilog.Exceptions.Filters;
 using Xunit;
 using static LogJsonOutputUtils;
 
-#pragma warning disable CA2208 // Instantiate argument exceptions correctly
 public class ExceptionDestructurerTest
 {
     [Fact]
@@ -218,4 +217,3 @@ public class ExceptionDestructurerTest
         }
     }
 }
-#pragma warning restore CA2208 // Instantiate argument exceptions correctly

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ExceptionPropertiesBagTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ExceptionPropertiesBagTest.cs
@@ -10,23 +10,18 @@ public class ExceptionPropertiesBagTest
     [Fact]
     public void Constructor_GivenNullException_Throws()
     {
-        // Act
         var ex = Assert.Throws<ArgumentNullException>(() => new ExceptionPropertiesBag(null!));
 
-        // Assert
         Assert.Equal("exception", ex.ParamName);
     }
 
     [Fact]
     public void AddedProperty_IsAvailableInReturnedDictionary()
     {
-        // Arrange
         var properties = new ExceptionPropertiesBag(new Exception(), null);
 
-        // Act
         properties.AddProperty("key", "value");
 
-        // Assert
         var results = properties.GetResultDictionary();
         Assert.Equal(1, results.Count);
         Assert.Contains("key", results.Keys);
@@ -37,43 +32,34 @@ public class ExceptionPropertiesBagTest
     [Fact]
     public void CannotAddProperty_WhenResultWasAlreadyAquired()
     {
-        // Arrange
         var properties = new ExceptionPropertiesBag(new Exception(), null);
         properties.AddProperty("key", "value");
         var results = properties.GetResultDictionary();
 
-        // Act
         var ex = Assert.Throws<InvalidOperationException>(() => properties.AddProperty("key2", "value2"));
 
-        // Assert
         Assert.Equal("Cannot add exception property 'key2' to bag, after results were already collected", ex.Message);
     }
 
     [Fact]
     public void CannotAddProperty_WhenKeyIsNull()
     {
-        // Arrange
         var properties = new ExceptionPropertiesBag(new Exception(), null);
 
-        // Act
         var ex = Assert.Throws<ArgumentNullException>(() => properties.AddProperty(null!, "value"));
 
-        // Assert
         Assert.Equal("key", ex.ParamName);
     }
 
     [Fact]
     public void AddedProperty_WhenFilterIsSetToIgnoreIt_IsSkipped()
     {
-        // Arrange
         var properties = new ExceptionPropertiesBag(
             new Exception(),
             new IgnorePropertyByNameExceptionFilter(new[] { "key" }));
 
-        // Act
         properties.AddProperty("key", "value");
 
-        // Assert
         var results = properties.GetResultDictionary();
         Assert.Equal(0, results.Count);
     }
@@ -81,15 +67,12 @@ public class ExceptionPropertiesBagTest
     [Fact]
     public void AddedProperty_WhenFilterIsNotSetToIgnoreIt_IsIncluded()
     {
-        // Arrange
         var properties = new ExceptionPropertiesBag(
             new Exception(),
             new IgnorePropertyByNameExceptionFilter(new[] { "not key" }));
 
-        // Act
         properties.AddProperty("key", "value");
 
-        // Assert
         var results = properties.GetResultDictionary();
         Assert.Equal(1, results.Count);
         Assert.Contains("key", results.Keys);

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ReflectionBasedDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ReflectionBasedDestructurerTest.cs
@@ -445,6 +445,14 @@ public class ReflectionBasedDestructurerTest
     private static ReflectionBasedDestructurer CreateReflectionBasedDestructurer() =>
         new(10);
 
+    [Serializable]
+    internal struct TestStruct
+    {
+        public int ValueType { get; set; }
+
+        public string ReferenceType { get; set; }
+    }
+
     public class MyObject
     {
         public string? Foo { get; set; }
@@ -562,14 +570,6 @@ public class ReflectionBasedDestructurerTest
     public class RecursiveException : Exception
     {
         public RecursiveNode? Node { get; set; }
-    }
-
-    [Serializable]
-    internal struct TestStruct
-    {
-        public int ValueType { get; set; }
-
-        public string ReferenceType { get; set; }
     }
 
     [Serializable]

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ReflectionBasedDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ReflectionBasedDestructurerTest.cs
@@ -490,16 +490,12 @@ public class ReflectionBasedDestructurerTest
     {
         public string? Foo { get; set; }
 
-#pragma warning disable CA2227 // Collection properties should be read only
         public Dictionary<string, object>? Reference { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
     }
 
     public class TypePropertyException : Exception
     {
-#pragma warning disable CA1721 // Property names should not match get methods
         public int? Type { get; set; }
-#pragma warning restore CA1721 // Property names should not match get methods
     }
 
     public class TestException : Exception
@@ -518,11 +514,9 @@ public class ReflectionBasedDestructurerTest
 
         public string PublicProperty { get; set; }
 
-#pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
 #pragma warning disable CA1822 // Member does not access instance data and can be marked as static
         public string ExceptionProperty => throw new Exception();
 #pragma warning restore CA1822 // Member does not access instance data and can be marked as static
-#pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
 
         internal string InternalProperty { get; set; }
 
@@ -532,9 +526,7 @@ public class ReflectionBasedDestructurerTest
         private string PrivateProperty { get; set; }
 #pragma warning restore IDE0052 // Remove unread private members
 
-#pragma warning disable CA1822 // Member does not access instance data and can be marked as static
         public string this[int i] => "IndexerValue";
-#pragma warning restore CA1822 // Member does not access instance data and can be marked as static
     }
 
     public class UriException : Exception
@@ -605,9 +597,7 @@ public class ReflectionBasedDestructurerTest
         public new T? HiddenProperty { get; set; }
     }
 
-#pragma warning disable CA1064 // Exceptions should be public
     internal class HiddenException : Exception
-#pragma warning restore CA1064 // Exceptions should be public
     {
         public HiddenException(string message, object info)
             : base(message) =>

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ReflectionBasedDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ReflectionBasedDestructurerTest.cs
@@ -27,7 +27,7 @@ public class ReflectionBasedDestructurerTest
         Assert.DoesNotContain(properties, x => string.Equals(x.Key, "ProtectedProperty", StringComparison.Ordinal));
         Assert.DoesNotContain(properties, x => string.Equals(x.Key, "PrivateProperty", StringComparison.Ordinal));
         Assert.Equal("MessageValue", properties[nameof(TestException.Message)]);
-#if NET461
+#if NET462
         Assert.StartsWith("Void DestructureComplexException_EachTypeOfPropertyIsDestructuredAsExpected(", properties[nameof(TestException.TargetSite)].ToString());
 #endif
         Assert.NotNull(properties[nameof(TestException.StackTrace)]?.ToString());

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ReflectionBasedDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ReflectionBasedDestructurerTest.cs
@@ -565,9 +565,7 @@ public class ReflectionBasedDestructurerTest
     }
 
     [Serializable]
-#pragma warning disable SA1201 // Elements should appear in the correct order
     internal struct TestStruct
-#pragma warning restore SA1201 // Elements should appear in the correct order
     {
         public int ValueType { get; set; }
 

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ReflectionBasedDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ReflectionBasedDestructurerTest.cs
@@ -5,7 +5,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Serilog.Exceptions.Core;
 using Serilog.Exceptions.Destructurers;
 using Xunit;
@@ -16,14 +15,11 @@ public class ReflectionBasedDestructurerTest
     [Fact]
     public void DestructureComplexException_EachTypeOfPropertyIsDestructuredAsExpected()
     {
-        // Arrange
         var exception = ThrowAndCatchException(() => throw new TestException());
         var propertiesBag = new ExceptionPropertiesBag(exception);
 
-        // Act
         CreateReflectionBasedDestructurer().Destructure(exception, propertiesBag, EmptyDestructurer());
 
-        // Assert
         var properties = propertiesBag.GetResultDictionary();
         Assert.Equal("PublicValue", properties[nameof(TestException.PublicProperty)]);
         Assert.Equal("threw System.Exception: Exception of type 'System.Exception' was thrown.", properties[nameof(TestException.ExceptionProperty)]);
@@ -31,7 +27,7 @@ public class ReflectionBasedDestructurerTest
         Assert.DoesNotContain(properties, x => string.Equals(x.Key, "ProtectedProperty", StringComparison.Ordinal));
         Assert.DoesNotContain(properties, x => string.Equals(x.Key, "PrivateProperty", StringComparison.Ordinal));
         Assert.Equal("MessageValue", properties[nameof(TestException.Message)]);
-#if NET461 || NET472
+#if NET461
         Assert.StartsWith("Void DestructureComplexException_EachTypeOfPropertyIsDestructuredAsExpected(", properties[nameof(TestException.TargetSite)].ToString());
 #endif
         Assert.NotNull(properties[nameof(TestException.StackTrace)]?.ToString());
@@ -101,13 +97,15 @@ public class ReflectionBasedDestructurerTest
         var properties = propertiesBag.GetResultDictionary();
         var destructuredTaskObject = (IDictionary?)properties[nameof(TaskCanceledException.Task)];
         var destructuredTaskProperties = Assert.IsAssignableFrom<IDictionary<string, object>>(destructuredTaskObject);
-        destructuredTaskProperties.Should().ContainKey(nameof(Task.Id));
-        destructuredTaskProperties.Should().ContainKey(nameof(Task.Status))
-            .WhoseValue.Should().BeOfType<string>()
-            .Which.Should().Be(nameof(TaskStatus.Canceled));
-        destructuredTaskProperties.Should().ContainKey(nameof(Task.CreationOptions))
-            .WhoseValue.Should().BeOfType<string>()
-            .Which.Should().Contain(nameof(TaskCreationOptions.None));
+        Assert.Contains(nameof(Task.Id), destructuredTaskProperties.Keys);
+
+        Assert.Contains(nameof(Task.Status), destructuredTaskProperties.Keys);
+        var value = Assert.IsType<string>(destructuredTaskProperties[nameof(Task.Status)]);
+        Assert.Equal(nameof(TaskStatus.Canceled), value);
+
+        Assert.Contains(nameof(Task.CreationOptions), destructuredTaskProperties.Keys);
+        var value2 = Assert.IsType<string>(destructuredTaskProperties[nameof(Task.CreationOptions)]);
+        Assert.Equal(nameof(TaskCreationOptions.None), value2);
     }
 
     [Fact]
@@ -123,32 +121,35 @@ public class ReflectionBasedDestructurerTest
         var properties = propertiesBag.GetResultDictionary();
         var destructuredTaskObject = (IDictionary?)properties[nameof(TaskCanceledException.Task)];
         var destructuredTaskProperties = Assert.IsAssignableFrom<IDictionary<string, object>>(destructuredTaskObject);
-        destructuredTaskProperties.Should().ContainKey(nameof(Task.Id));
-        destructuredTaskProperties.Should().ContainKey(nameof(Task.Status))
-            .WhoseValue.Should().BeOfType<string>()
-            .Which.Should().Be(nameof(TaskStatus.Faulted));
-        destructuredTaskProperties.Should().ContainKey(nameof(Task.CreationOptions))
-            .WhoseValue.Should().BeOfType<string>()
-            .Which.Should().Be(nameof(TaskCreationOptions.None));
-        var taskFirstLevelExceptionDictionary = destructuredTaskProperties.Should().ContainKey(nameof(Task.Exception))
-            .WhoseValue.Should().BeAssignableTo<IDictionary<string, object>>()
-            .Which;
-        taskFirstLevelExceptionDictionary.Should().ContainKey("Message")
-            .WhoseValue.Should().BeOfType<string>()
-            .Which.Should().Contain("One or more errors occurred.", "task's first level exception is aggregate exception");
-        taskFirstLevelExceptionDictionary.Should().ContainKey("InnerExceptions")
-            .WhoseValue.Should().BeAssignableTo<IReadOnlyCollection<object>>()
-            .Which.Should().ContainSingle()
-            .Which.Should().BeAssignableTo<IDictionary<string, object>>()
-            .Which.Should().ContainKey("Message")
-            .WhoseValue.Should().BeOfType<string>()
-            .Which.Should().Be("INNER EXCEPTION MESSAGE");
+        Assert.Contains(nameof(Task.Id), destructuredTaskProperties.Keys);
+
+        Assert.Contains(nameof(Task.Status), destructuredTaskProperties.Keys);
+        var status = Assert.IsType<string>(destructuredTaskProperties[nameof(Task.Status)]);
+        Assert.Equal(nameof(TaskStatus.Faulted), status);
+
+        Assert.Contains(nameof(Task.CreationOptions), destructuredTaskProperties.Keys);
+        var creationOptions = Assert.IsType<string>(destructuredTaskProperties[nameof(Task.CreationOptions)]);
+        Assert.Equal(nameof(TaskCreationOptions.None), creationOptions);
+
+        Assert.Contains(nameof(Task.Exception), destructuredTaskProperties.Keys);
+        var taskFirstLevelExceptionDictionary = Assert.IsAssignableFrom<IDictionary<string, object>>(destructuredTaskProperties[nameof(Task.Exception)]);
+        Assert.Equal(nameof(TaskCreationOptions.None), creationOptions);
+
+        Assert.Contains("Message", taskFirstLevelExceptionDictionary.Keys);
+        var message = Assert.IsType<string>(taskFirstLevelExceptionDictionary["Message"]);
+        Assert.Equal("One or more errors occurred. (INNER EXCEPTION MESSAGE)", message);
+
+        Assert.Contains("InnerExceptions", taskFirstLevelExceptionDictionary.Keys);
+        var innerExceptions = Assert.IsAssignableFrom<IReadOnlyCollection<object>>(taskFirstLevelExceptionDictionary["InnerExceptions"]);
+        var innerException = Assert.Single(innerExceptions);
+        var innerExceptionDictionary = Assert.IsAssignableFrom<IDictionary<string, object>>(innerException);
+        Assert.Contains("Message", innerExceptionDictionary.Keys);
+        Assert.Equal("INNER EXCEPTION MESSAGE", innerExceptionDictionary["Message"]);
     }
 
     [Fact]
     public void CanDestructureStructDataItem()
     {
-        // Arrange
         var exception = new Exception("test");
         exception.Data["data"] = new TestStruct()
         {
@@ -157,10 +158,8 @@ public class ReflectionBasedDestructurerTest
         };
         var propertiesBag = new ExceptionPropertiesBag(exception);
 
-        // Act
         CreateReflectionBasedDestructurer().Destructure(exception, propertiesBag, EmptyDestructurer());
 
-        // Assert
         var properties = propertiesBag.GetResultDictionary();
         var data = (IDictionary?)properties[nameof(Exception.Data)];
         var testStructDataValue = data?["data"];
@@ -170,7 +169,6 @@ public class ReflectionBasedDestructurerTest
     [Fact]
     public void CanDestructureClassDataItem()
     {
-        // Arrange
         var exception = new Exception("test");
         exception.Data["data"] = new TestClass()
         {
@@ -179,10 +177,8 @@ public class ReflectionBasedDestructurerTest
         };
         var propertiesBag = new ExceptionPropertiesBag(exception);
 
-        // Act
         CreateReflectionBasedDestructurer().Destructure(exception, propertiesBag, EmptyDestructurer());
 
-        // Assert
         var properties = propertiesBag.GetResultDictionary();
         var data = (IDictionary?)properties[nameof(Exception.Data)];
         var testStructDataValue = data?["data"];
@@ -194,7 +190,6 @@ public class ReflectionBasedDestructurerTest
     [Fact]
     public void DestructuringDepthIsLimitedByConfiguredDepth()
     {
-        // Arrange
         var exception = new RecursiveException()
         {
             Node = new RecursiveNode()
@@ -212,11 +207,9 @@ public class ReflectionBasedDestructurerTest
         };
         var destructurer = new ReflectionBasedDestructurer(1);
 
-        // Act
         var propertiesBag = new ExceptionPropertiesBag(exception);
         destructurer.Destructure(exception, propertiesBag, EmptyDestructurer());
 
-        // Assert
         // Parent is depth 1
         // First child is depth 2
         var properties = propertiesBag.GetResultDictionary();
@@ -235,7 +228,6 @@ public class ReflectionBasedDestructurerTest
     [Fact]
     public void WhenObjectContainsCyclicReferences_ThenNoStackoverflowExceptionIsThrown()
     {
-        // Arrange
         var exception = new CyclicException
         {
             MyObject = new MyObject(),
@@ -244,14 +236,11 @@ public class ReflectionBasedDestructurerTest
         exception.MyObject.Reference = exception.MyObject;
         exception.MyObject.Reference2 = exception.MyObject;
 
-        // Act
         var result = new ExceptionPropertiesBag(new Exception());
         var destructurer = new ReflectionBasedDestructurer(10);
         destructurer.Destructure(exception, result, EmptyDestructurer());
 
-        // Assert
         var myObject = (Dictionary<string, object?>?)result.GetResultDictionary()["MyObject"];
-
         Assert.Equal("bar", myObject?["Foo"]);
         var reference1 = (Dictionary<string, object?>?)myObject?["Reference"];
         Assert.Equal(myObject?["$id"], reference1?["$ref"]);
@@ -263,7 +252,6 @@ public class ReflectionBasedDestructurerTest
     [Fact]
     public void WhenObjectContainsCyclicReferencesInList_ThenRecursiveDestructureIsImmediatelyStopped()
     {
-        // Arrange
         var cyclic = new MyObjectCollection
         {
             Foo = "Cyclic",
@@ -276,12 +264,10 @@ public class ReflectionBasedDestructurerTest
         exception.MyObjectCollection.Foo = "bar";
         exception.MyObjectCollection.Reference = cyclic;
 
-        // Act
         var result = new ExceptionPropertiesBag(new Exception());
         var destructurer = new ReflectionBasedDestructurer(10);
         destructurer.Destructure(exception, result, EmptyDestructurer());
 
-        // Assert
         var myObject = (List<object?>?)result.GetResultDictionary()[nameof(Cyclic2Exception.MyObjectCollection)];
 
         // exception.MyObjectCollection[0] is still list
@@ -295,7 +281,6 @@ public class ReflectionBasedDestructurerTest
     [Fact]
     public void WhenObjectContainsCyclicReferencesInDict_ThenRecursiveDestructureIsImmediatelyStopped()
     {
-        // Arrange
         var cyclic = new MyObjectDict
         {
             Foo = "Cyclic",
@@ -307,12 +292,10 @@ public class ReflectionBasedDestructurerTest
             MyObjectDict = cyclic,
         };
 
-        // Act
         var result = new ExceptionPropertiesBag(new Exception());
         var destructurer = new ReflectionBasedDestructurer(10);
         destructurer.Destructure(exception, result, EmptyDestructurer());
 
-        // Assert
         var myObject = (Dictionary<string, object?>?)result.GetResultDictionary()["MyObjectDict"];
 
         // exception.MyObjectDict["Reference"] is still regular dictionary
@@ -329,39 +312,36 @@ public class ReflectionBasedDestructurerTest
     [Fact]
     public void WhenObjectContainsCyclicReferencesInTask_ThenRecursiveDestructureIsImmediatelyStopped()
     {
-        // Arrange
         var exception = new CyclicTaskException();
         var task = Task.FromException(exception);
         exception.Task = task;
 
-        // Act
         var result = new ExceptionPropertiesBag(exception);
         var destructurer = CreateReflectionBasedDestructurer();
         destructurer.Destructure(exception, result, InnerDestructurer(destructurer));
 
-        // Assert
         var resultsDictionary = result.GetResultDictionary();
-        var destructuredTask = resultsDictionary[nameof(CyclicTaskException.Task)].Should().BeAssignableTo<IDictionary<string, object>>().Which;
-        var destructuredCyclicException = destructuredTask.Should().ContainKey(nameof(Task.Exception))
-            .WhoseValue.Should().BeAssignableTo<IDictionary<string, object>>()
-            .Which.Should().ContainKey(nameof(AggregateException.InnerExceptions))
-            .WhoseValue.Should().BeAssignableTo<IReadOnlyCollection<object>>()
-            .Which.Should().ContainSingle()
-            .Which.Should().BeAssignableTo<IDictionary<string, object>>().Which;
-        destructuredCyclicException.Should().ContainKey(nameof(Exception.Message))
-            .WhoseValue.Should().BeOfType<string>()
-            .Which.Should().Contain(nameof(CyclicTaskException));
-        destructuredCyclicException.Should().ContainKey(nameof(CyclicTaskException.Task))
-            .WhoseValue.Should().BeAssignableTo<IDictionary<string, object>>()
-            .Which.Should().ContainKey("$ref", "task was already destructured, so inner task should just contain ref");
+        var destructuredTask = Assert.IsAssignableFrom<IDictionary<string, object>>(resultsDictionary[nameof(CyclicTaskException.Task)]);
+        Assert.Contains(nameof(Task.Exception), destructuredTask.Keys);
+        var exceptionDictionary = Assert.IsAssignableFrom<IDictionary<string, object>>(destructuredTask[nameof(Task.Exception)]);
+        Assert.Contains(nameof(AggregateException.InnerExceptions), exceptionDictionary.Keys);
+        var innerExceptions = Assert.IsAssignableFrom<IReadOnlyCollection<object>>(exceptionDictionary[nameof(AggregateException.InnerExceptions)]);
+        var innerException = Assert.Single(innerExceptions);
+        var destructuredCyclicException = Assert.IsAssignableFrom<IDictionary<string, object>>(innerException);
+
+        Assert.Contains(nameof(Exception.Message), destructuredCyclicException.Keys);
+        var message = Assert.IsType<string>(destructuredCyclicException[nameof(Exception.Message)]);
+        Assert.Contains(nameof(CyclicTaskException), message);
+
+        Assert.Contains(nameof(CyclicTaskException.Task), destructuredCyclicException.Keys);
+        var task2 = Assert.IsAssignableFrom<IDictionary<string, object>>(destructuredCyclicException[nameof(CyclicTaskException.Task)]);
+        Assert.Contains("$ref", task2);
     }
 
     [Fact]
     public void WhenDestruringArgumentException_ResultShouldBeEquivalentToArgumentExceptionDestructurer()
     {
-#pragma warning disable CA2208 // Instantiate argument exceptions correctly
         var exception = ThrowAndCatchException(() => throw new ArgumentException("MESSAGE", "paramName"));
-#pragma warning restore CA2208 // Instantiate argument exceptions correctly
         Test_ResultOfReflectionDestructurerShouldBeEquivalentToCustomOne(exception, new ArgumentExceptionDestructurer());
     }
 
@@ -420,20 +400,17 @@ public class ReflectionBasedDestructurerTest
         Exception exception,
         IExceptionDestructurer customDestructurer)
     {
-        // Arrange
         var reflectionBasedResult = new ExceptionPropertiesBag(exception);
         var customBasedResult = new ExceptionPropertiesBag(exception);
         var reflectionBasedDestructurer = CreateReflectionBasedDestructurer();
 
-        // Act
         reflectionBasedDestructurer.Destructure(exception, reflectionBasedResult, InnerDestructurer(reflectionBasedDestructurer));
         customDestructurer.Destructure(exception, customBasedResult, InnerDestructurer(new ArgumentExceptionDestructurer()));
 
-        // Assert
         var reflectionBasedDictionary = (Dictionary<string, object>)reflectionBasedResult.GetResultDictionary();
         var customBasedDictionary = (Dictionary<string, object>)customBasedResult.GetResultDictionary();
 
-        reflectionBasedDictionary.Should().BeEquivalentTo(customBasedDictionary);
+        Assert.Equivalent(customBasedDictionary, reflectionBasedDictionary);
     }
 
     private static Func<Exception, IReadOnlyDictionary<string, object?>> EmptyDestructurer() =>
@@ -456,9 +433,7 @@ public class ReflectionBasedDestructurerTest
         {
             throwingAction();
         }
-#pragma warning disable CA1031 // Do not catch general exception types
         catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
         {
             return ex;
         }

--- a/Tests/Serilog.Exceptions.Test/Destructurers/TaskCanceledExceptionDestructurerTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/TaskCanceledExceptionDestructurerTest.cs
@@ -3,7 +3,6 @@ namespace Serilog.Exceptions.Test.Destructurers;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using static LogJsonOutputUtils;
@@ -15,20 +14,17 @@ public sealed class TaskCanceledExceptionDestructurerTest : IDisposable
     [Fact]
     public void TaskCanceledException_SimplePropertiesAreAttached()
     {
-        // Arrange
         this.cancellationTokenSource.Cancel();
         var task = Task.FromCanceled(this.cancellationTokenSource.Token);
 
-        // Act
         var ex = new TaskCanceledException(task);
 
-        // Assert
-        var tce = ex.Should().BeOfType<TaskCanceledException>().Which;
+        var tce = Assert.IsType<TaskCanceledException>(ex);
         var exceptionDetails = ExtractExceptionDetails(LogAndDestructureException(tce));
         Assert_ContainsPropertyWithValue(exceptionDetails, nameof(TaskCanceledException.CancellationToken), "CancellationRequested: true");
 
         var taskProperty = ExtractProperty(exceptionDetails, nameof(TaskCanceledException.Task));
-        var taskPropertyObject = taskProperty.Value.Should().BeOfType<JObject>().Which;
+        var taskPropertyObject = Assert.IsType<JObject>(taskProperty.Value);
         Assert_ContainsPropertyWithValue(taskPropertyObject, nameof(Task.Status), nameof(TaskStatus.Canceled));
         Assert_ContainsPropertyWithValue(taskPropertyObject, nameof(Task.CreationOptions), nameof(TaskCreationOptions.None));
     }
@@ -36,30 +32,23 @@ public sealed class TaskCanceledExceptionDestructurerTest : IDisposable
     [Fact]
     public void TaskCanceledException_TaskWithSomeCreationOptions_TheyAreDestructured()
     {
-        // Arrange
         var task = new Task(() => { }, TaskCreationOptions.LongRunning | TaskCreationOptions.PreferFairness);
 
-        // Act
         var ex = new TaskCanceledException(task);
 
-        // Assert
-        var tce = ex.Should().BeOfType<TaskCanceledException>().Which;
+        var tce = Assert.IsType<TaskCanceledException>(ex);
         var exceptionDetails = ExtractExceptionDetails(LogAndDestructureException(tce));
         var taskProperty = ExtractProperty(exceptionDetails, nameof(TaskCanceledException.Task));
-        var taskPropertyObject = taskProperty.Value.Should().BeOfType<JObject>().Which;
+        var taskPropertyObject = Assert.IsType<JObject>(taskProperty.Value);
         Assert_ContainsPropertyWithValue(taskPropertyObject, nameof(Task.CreationOptions), $"{nameof(TaskCreationOptions.PreferFairness)}, {nameof(TaskCreationOptions.LongRunning)}");
     }
 
     [Fact]
     public void TaskCanceledException_TaskNull()
     {
-        // Arrange
-
-        // Act
         var ex = new TaskCanceledException();
 
-        // Assert
-        var tce = ex.Should().BeOfType<TaskCanceledException>().Which;
+        var tce = Assert.IsType<TaskCanceledException>(ex);
         var exceptionDetails = ExtractExceptionDetails(LogAndDestructureException(tce));
         Assert_ContainsPropertyWithValue(exceptionDetails, nameof(TaskCanceledException.Task), null);
     }
@@ -67,31 +56,26 @@ public sealed class TaskCanceledExceptionDestructurerTest : IDisposable
     [Fact]
     public void FaultedTaskCanceledException_SimplePropertiesAreAttached()
     {
-        // Arrange
         var innerException = new Exception("Inner exception message");
         var task = Task.FromException(innerException);
         var ex = new TaskCanceledException(task);
 
-        // Act
         var exceptionDetails = ExtractExceptionDetails(LogAndDestructureException(ex));
 
-        // Assert
         Assert_ContainsPropertyWithValue(exceptionDetails, "CancellationToken", "CancellationRequested: false");
 
         var taskProperty = ExtractProperty(exceptionDetails, nameof(TaskCanceledException.Task));
-        var taskPropertyObject = taskProperty.Value.Should().BeOfType<JObject>().Which;
+        var taskPropertyObject = Assert.IsType<JObject>(taskProperty.Value);
         Assert_ContainsPropertyWithValue(taskPropertyObject, nameof(Task.Status), nameof(TaskStatus.Faulted));
         Assert_ContainsPropertyWithValue(taskPropertyObject, nameof(Task.CreationOptions), nameof(TaskCreationOptions.None));
         var taskException = ExtractProperty(taskPropertyObject, nameof(Task.Exception));
-        var taskExceptionObject = taskException.Should().BeOfType<JProperty>()
-            .Which.Value.Should().BeOfType<JObject>()
-            .Which;
+        var taskExceptionObject = Assert.IsType<JObject>(taskException.Value);
 
         var typeOfTaskException = ExtractProperty(taskExceptionObject, "Type");
-        typeOfTaskException.Should().BeOfType<JProperty>()
-            .Which.Value.Should().BeOfType<JValue>()
-            .Which.Value.Should().BeOfType<string>()
-            .Which.Should().Be("System.AggregateException");
+        var jsonProperty = Assert.IsType<JProperty>(typeOfTaskException);
+        var jsonValue = Assert.IsType<JValue>(jsonProperty.Value);
+        var value = Assert.IsType<string>(jsonValue.Value);
+        Assert.Equal("System.AggregateException", value);
     }
 
     public void Dispose() => this.cancellationTokenSource?.Dispose();

--- a/Tests/Serilog.Exceptions.Test/Filters/CompositeExceptionPropertyFilterTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Filters/CompositeExceptionPropertyFilterTest.cs
@@ -19,65 +19,54 @@ public class CompositeExceptionPropertyFilterTest
     [Fact]
     public void CreationOfCompositeFilter_ForOneNullFilter_Throws()
     {
-        // Act
         var ex = Assert.Throws<ArgumentException>(
             () => new CompositeExceptionPropertyFilter(new IExceptionPropertyFilter[] { null! }));
 
-        // Assert
         Assert.Contains("index 0", ex.Message, StringComparison.Ordinal);
     }
 
     [Fact]
     public void ShouldFilterTheProperty_WhenFirstFilterFilters_Filters()
     {
-        // Arrange
         var filterA = new IgnorePropertyByNameExceptionFilter("A");
         var filterB = new IgnorePropertyByNameExceptionFilter("B");
         var composite = new CompositeExceptionPropertyFilter(filterA, filterB);
 
-        // Act
         var shouldFilter = composite.ShouldPropertyBeFiltered(
             new Exception(),
             "B",
             1);
 
-        // Assert
         Assert.True(shouldFilter);
     }
 
     [Fact]
     public void ShouldFilterTheProperty_WhenSecondFilterFilters_Filters()
     {
-        // Arrange
         var filterA = new IgnorePropertyByNameExceptionFilter("A");
         var filterB = new IgnorePropertyByNameExceptionFilter("B");
         var composite = new CompositeExceptionPropertyFilter(filterA, filterB);
 
-        // Act
         var shouldFilter = composite.ShouldPropertyBeFiltered(
             new Exception(),
             "A",
             1);
 
-        // Assert
         Assert.True(shouldFilter);
     }
 
     [Fact]
     public void ShouldFilterTheProperty_WhenNoFilterFilters_NotFilters()
     {
-        // Arrange
         var filterA = new IgnorePropertyByNameExceptionFilter("A");
         var filterB = new IgnorePropertyByNameExceptionFilter("B");
         var composite = new CompositeExceptionPropertyFilter(filterA, filterB);
 
-        // Act
         var shouldFilter = composite.ShouldPropertyBeFiltered(
             new Exception(),
             "C",
             1);
 
-        // Assert
         Assert.False(shouldFilter);
     }
 }

--- a/Tests/Serilog.Exceptions.Test/Reflection/ReflectionInfoExtractorTest.cs
+++ b/Tests/Serilog.Exceptions.Test/Reflection/ReflectionInfoExtractorTest.cs
@@ -1,7 +1,6 @@
 namespace Serilog.Exceptions.Test.Reflection;
 
 using System.Linq;
-using FluentAssertions;
 using Serilog.Exceptions.Reflection;
 using Xunit;
 
@@ -16,20 +15,20 @@ public class ReflectionInfoExtractorTest
 
         var reflectionInfo = this.reflectionInfoExtractor.GetOrCreateReflectionInfo(typeof(TestObjectWithRedefinedProperty));
 
-        reflectionInfo.Properties.Should().HaveCount(2);
+        Assert.Equal(2, reflectionInfo.Properties.Length);
 
-        var namePropertyInfo = reflectionInfo.Properties.Should().ContainSingle(x => x.Name == "Name").Which;
-        namePropertyInfo.Name.Should().Be(nameof(TestObjectWithRedefinedProperty.Name));
-        namePropertyInfo.DeclaringType.Should().Be(typeof(TestObjectWithRedefinedProperty));
+        var namePropertyInfo = Assert.Single(reflectionInfo.Properties, x => x.Name == "Name");
+        Assert.Equal(nameof(TestObjectWithRedefinedProperty.Name), namePropertyInfo.Name);
+        Assert.Equal(typeof(TestObjectWithRedefinedProperty), namePropertyInfo.DeclaringType);
         var nameGetter = namePropertyInfo.Getter;
         var testObjectName = nameGetter(testObject);
-        testObjectName.Should().BeOfType<int>().Which.Should().Be(123);
+        var integer = Assert.IsType<int>(testObjectName);
+        Assert.Equal(123, integer);
 
-        var baseClassPropertyInfo = reflectionInfo
-            .Properties.Should().ContainSingle(x => x.Name == "TestObject.Name").Which;
+        var baseClassPropertyInfo = Assert.Single(reflectionInfo.Properties, x => x.Name == "TestObject.Name");
         var baseClassNameGetter = baseClassPropertyInfo.Getter;
         var baseClassTestObjectName = baseClassNameGetter(testObject);
-        baseClassTestObjectName.Should().BeNull();
+        Assert.Null(baseClassTestObjectName);
     }
 
     [Fact]
@@ -42,20 +41,22 @@ public class ReflectionInfoExtractorTest
         var propertyNames = reflectionInfo.Properties
             .Select(x => x.Name)
             .ToList();
-        propertyNames.Should().BeEquivalentTo(
+        Assert.Equivalent(
             new[]
             {
-                    "Name",
-                    "TestObjectWithRedefinedProperty.Name",
-                    "TestObject.Name",
+                "Name",
+                "TestObjectWithRedefinedProperty.Name",
+                "TestObject.Name",
             },
-            x => x.WithoutStrictOrdering());
-        var namePropertyInfo = reflectionInfo.Properties.Should().ContainSingle(x => x.Name == "Name").Which;
-        namePropertyInfo.Name.Should().Be(nameof(TestObjectWithDoubleRedefinedProperty.Name));
-        namePropertyInfo.DeclaringType.Should().Be(typeof(TestObjectWithDoubleRedefinedProperty));
+            propertyNames);
+
+        var namePropertyInfo = Assert.Single(reflectionInfo.Properties, x => x.Name == "Name");
+        Assert.Equal(nameof(TestObjectWithDoubleRedefinedProperty.Name), namePropertyInfo.Name);
+        Assert.Equal(typeof(TestObjectWithDoubleRedefinedProperty), namePropertyInfo.DeclaringType);
         var nameGetter = namePropertyInfo.Getter;
         var testObjectName = nameGetter(testObject);
-        testObjectName.Should().BeOfType<double>().Which.Should().Be(456.789);
+        var number = Assert.IsType<double>(testObjectName);
+        Assert.Equal(456.789, number);
     }
 
     public class TestObject

--- a/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
+++ b/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References (.NET 7)" Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0-preview.7.22376.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="Package References (.NET 6)" Condition="'$(TargetFramework)' == 'net6.0'">

--- a/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
+++ b/Tests/Serilog.Exceptions.Test/Serilog.Exceptions.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net6.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Signing">
@@ -17,16 +17,15 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="FluentAssertions" Version="6.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Label="Package References (.NET 7)" Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0-preview.7.22376.2" />
   </ItemGroup>
 
   <ItemGroup Label="Package References (.NET 6)" Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Label="Package References (.NET 5)" Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tools/ExceptionFinderTool/ExceptionFinderTool.csproj
+++ b/Tools/ExceptionFinderTool/ExceptionFinderTool.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup Label="Build">
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;net472;net461</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup Label="Package References (.NET)" Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Label="Package References (.NET)" Condition="'$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>
 

--- a/Tools/ExceptionFinderTool/ExceptionFinderTool.csproj
+++ b/Tools/ExceptionFinderTool/ExceptionFinderTool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup Label="Build">
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,10 +49,10 @@ stages:
               packageType: "sdk"
               version: 3.1.x
           - task: UseDotNet@2
-            displayName: "Install .NET Core 5.0 SDK"
+            displayName: "Install .NET Core 6.0 SDK"
             inputs:
               packageType: "sdk"
-              version: 5.0.x
+              version: 6.0.x
           - task: UseDotNet@2
             displayName: "Install .NET Core SDK"
             inputs:

--- a/build.cake
+++ b/build.cake
@@ -51,9 +51,9 @@ Task("Test")
                     Configuration = configuration,
                     Loggers = new string[]
                     {
-                        $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
-                        $"junit;LogFileName={project.GetFilenameWithoutExtension()}.xml",
-                        $"html;LogFileName={project.GetFilenameWithoutExtension()}.html",
+                        $"trx;LogFilePrefix={project.GetFilenameWithoutExtension()}",
+                        $"junit;LogFilePrefix={project.GetFilenameWithoutExtension()}",
+                        $"html;LogFilePrefix={project.GetFilenameWithoutExtension()}",
                     },
                     NoBuild = true,
                     NoRestore = true,

--- a/build.cake
+++ b/build.cake
@@ -52,7 +52,7 @@ Task("Test")
                     Loggers = new string[]
                     {
                         $"trx;LogFilePrefix={project.GetFilenameWithoutExtension()}",
-                        $"junit;LogFilePrefix={project.GetFilenameWithoutExtension()}",
+                        $"junit;LogFileName={project.GetFilenameWithoutExtension()}_{{framework}}.xml",
                         $"html;LogFilePrefix={project.GetFilenameWithoutExtension()}",
                     },
                     NoBuild = true,

--- a/build.cake
+++ b/build.cake
@@ -38,26 +38,28 @@ Task("Build")
 
 Task("Test")
     .Description("Runs unit tests and outputs test results to the artefacts directory.")
-    .DoesForEach(GetFiles("./Tests/**/*.csproj"), project =>
-    {
-        DotNetTest(
-            project.ToString(),
-            new DotNetTestSettings()
-            {
-                Blame = true,
-                Collectors = new string[] { "Code Coverage", "XPlat Code Coverage" },
-                Configuration = configuration,
-                Loggers = new string[]
+    .DoesForEach(
+        GetFiles("./Tests/**/*.csproj"),
+        project =>
+        {
+            DotNetTest(
+                project.ToString(),
+                new DotNetTestSettings()
                 {
-                    $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
-                    $"junit;LogFileName={project.GetFilenameWithoutExtension()}.xml",
-                    $"html;LogFileName={project.GetFilenameWithoutExtension()}.html",
-                },
-                NoBuild = true,
-                NoRestore = true,
-                ResultsDirectory = artefactsDirectory,
-            });
-    });
+                    Blame = true,
+                    Collectors = new string[] { "Code Coverage", "XPlat Code Coverage" },
+                    Configuration = configuration,
+                    Loggers = new string[]
+                    {
+                        $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
+                        $"junit;LogFileName={project.GetFilenameWithoutExtension()}.xml",
+                        $"html;LogFileName={project.GetFilenameWithoutExtension()}.html",
+                    },
+                    NoBuild = true,
+                    NoRestore = true,
+                    ResultsDirectory = artefactsDirectory,
+                });
+        });
 
 Task("Pack")
     .Description("Creates NuGet packages and outputs them to the artefacts directory.")

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.3.0",
+      "version": "3.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "allowPrerelease": true,
+    "allowPrerelease": false,
     "rollForward": "latestMajor",
-    "version": "7.0.100-rc.1.22431.12"
+    "version": "7.0.100"
   }
 }

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": true,
     "rollForward": "latestMajor",
-    "version": "6.0.402"
+    "version": "7.0.100-rc.1.22431.12"
   }
 }


### PR DESCRIPTION
- Add .NET 7 target.
- Drop .NET 5 target.
- Update build scripts to install .NET 7 and 6 and stop installing 5.
- Update net561 to net462.
- Uses C# 11 features resulting in cleaner code.
- Drop `FluentAssertions` as it was only used in a few places and required dependabot updates.
- Switch `dotnet test --logger` to use `LogFilePrefix`.
