### PR TITLE
fix: corrected ef warning anchor link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The code above logs the following:
 ## Getting Started
 
 **Warning Entity Framework Core Users:**
-If you are using Entity Framework with Serilog.Exceptions you should read the [following instructions](#serilogexceptionsentityframeworkcore).
+If you are using Entity Framework with Serilog.Exceptions you should read the [following instructions](#SerilogExceptionsEntityFrameworkCore).
 
 Add the [Serilog.Exceptions](https://www.nuget.org/packages/Serilog.Exceptions/) NuGet package to your project using the NuGet Package Manager or run the following command in the Package Console Window:
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The code above logs the following:
 ## Getting Started
 
 **Warning Entity Framework Core Users:**
-If you are using Entity Framework with Serilog.Exceptions you should read the [following instructions](#Serilog.Exceptions.EntityFrameworkCore).
+If you are using Entity Framework with Serilog.Exceptions you should read the [following instructions](#serilogexceptionsentityframeworkcore).
 
 Add the [Serilog.Exceptions](https://www.nuget.org/packages/Serilog.Exceptions/) NuGet package to your project using the NuGet Package Manager or run the following command in the Package Console Window:
 


### PR DESCRIPTION
Hello! Thank you for creating this project. I've just stumbled upon this and was reading `README` when noticed warning for EF Core users. Warning looks quite important, but link to it seems to be invalid.

This PR fixes anchor link to warning for EF Core users. Change was tested in `Google Chrome Version 114.0.5735.106 (Official Build) (64-bit)`.