### PR TITLE
feat: added ValidationApiExceptionDestructurer and unit tests.

### DIFF
--- a/Source/Serilog.Exceptions.Refit/Destructurers/ValidationApiExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions.Refit/Destructurers/ValidationApiExceptionDestructurer.cs
@@ -1,0 +1,76 @@
+namespace Serilog.Exceptions.Refit.Destructurers;
+
+using System;
+using System.Collections.Generic;
+using global::Refit;
+using Serilog.Exceptions.Core;
+using Serilog.Exceptions.Destructurers;
+
+/// <summary>
+/// A destructurer for the Refit <see cref="ValidationApiExceptionDestructurer"/>.
+/// </summary>
+/// <seealso cref="ExceptionDestructurer" />
+public class ValidationApiExceptionDestructurer : ExceptionDestructurer
+{
+    private readonly bool destructureCommonExceptionProperties;
+    private readonly bool destructureHttpContent;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValidationApiExceptionDestructurer"/> class.
+    /// </summary>
+    /// <param name="destructureCommonExceptionProperties">Destructure common public Exception properties or not.</param>
+    /// <param name="destructureHttpContent">Destructure the HTTP body. This is left optional due to possible security and log size concerns.</param>
+    public ValidationApiExceptionDestructurer(bool destructureCommonExceptionProperties = true, bool destructureHttpContent = false)
+    {
+        this.destructureCommonExceptionProperties = destructureCommonExceptionProperties;
+        this.destructureHttpContent = destructureHttpContent;
+    }
+
+    /// <inheritdoc cref="IExceptionDestructurer.TargetTypes"/>
+    public override Type[] TargetTypes => new[] { typeof(ValidationApiException) };
+
+    /// <inheritdoc />
+    public override void Destructure(Exception exception, IExceptionPropertiesBag propertiesBag, Func<Exception, IReadOnlyDictionary<string, object?>?> destructureException)
+    {
+        if (this.destructureCommonExceptionProperties)
+        {
+            base.Destructure(exception, propertiesBag, destructureException);
+        }
+        else
+        {
+            // Argument checks are usually done in <see cref="ExceptionDestructurer.Destructure"/>
+            // but as we didn't call this method we need to do the checks here.
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(exception);
+            ArgumentNullException.ThrowIfNull(propertiesBag);
+            ArgumentNullException.ThrowIfNull(destructureException);
+#else
+            if (exception is null)
+            {
+                throw new ArgumentNullException(nameof(exception));
+            }
+
+            if (propertiesBag is null)
+            {
+                throw new ArgumentNullException(nameof(propertiesBag));
+            }
+
+            if (destructureException is null)
+            {
+                throw new ArgumentNullException(nameof(destructureException));
+            }
+#endif
+        }
+
+#pragma warning disable CA1062 // Validate arguments of public methods
+        var validationApiException = (ValidationApiException)exception;
+        if (this.destructureHttpContent)
+        {
+            propertiesBag.AddProperty(nameof(ValidationApiException.Content), validationApiException.Content);
+        }
+
+        propertiesBag.AddProperty(nameof(ValidationApiException.Uri), validationApiException.Uri);
+        propertiesBag.AddProperty(nameof(ValidationApiException.StatusCode), validationApiException.StatusCode);
+#pragma warning restore CA1062 // Validate arguments of public methods
+    }
+}

--- a/Tests/Serilog.Exceptions.Test/Destructurers/LogJsonOutputUtils.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/LogJsonOutputUtils.cs
@@ -38,6 +38,12 @@ public static class LogJsonOutputUtils
         Assert_JObjectContainsPropertiesExceptionDetailsWithProperty(rootObject, propertyKey, propertyValue);
     }
 
+    public static void Test_LoggedExceptionContainsProperty(Exception exception, string propertyKey, string problemDetailPropertyKey, string? propertyValue, IDestructuringOptions? destructuringOptions = null)
+    {
+        var rootObject = LogAndDestructureException(exception, destructuringOptions);
+        Assert_JObjectContainsPropertiesExceptionDetailsWithProblemDetailsProperty(rootObject, propertyKey, problemDetailPropertyKey, propertyValue);
+    }
+
     public static void Test_LoggedExceptionDoesNotContainProperty(Exception exception, string propertyKey, IDestructuringOptions? destructuringOptions = null)
     {
         var rootObject = LogAndDestructureException(exception, destructuringOptions);
@@ -94,6 +100,22 @@ public static class LogJsonOutputUtils
         }
     }
 
+    public static void Assert_ContainsPropertyWithProblemDetailsObject(
+        JObject jObject,
+        string propertyKey,
+        string problemDetailPropertyKey,
+        string? propertyValue)
+    {
+        var paramNameProperty = ExtractProperty(jObject, propertyKey);
+        var objectValue = Assert.IsType<JObject>(paramNameProperty.Value);
+        var problemDetailProperty = ExtractProperty(objectValue, problemDetailPropertyKey);
+
+        if (problemDetailProperty.Value is not null)
+        {
+            Assert.Equal(problemDetailProperty.Value.ToString(), propertyValue);
+        }
+    }
+
     public static void Assert_DoesNotContainProperty(
         JObject jObject,
         string propertyKey)
@@ -131,6 +153,16 @@ public static class LogJsonOutputUtils
     {
         var exceptionDetailValue = ExtractExceptionDetails(jObject);
         Assert_ContainsPropertyWithValue(exceptionDetailValue, propertyKey, propertyValue);
+    }
+
+    public static void Assert_JObjectContainsPropertiesExceptionDetailsWithProblemDetailsProperty(
+        JObject jObject,
+        string propertyKey,
+        string problemDetailPropertyKey,
+        string? propertyValue)
+    {
+        var exceptionDetailValue = ExtractExceptionDetails(jObject);
+        Assert_ContainsPropertyWithProblemDetailsObject(exceptionDetailValue, propertyKey, problemDetailPropertyKey, propertyValue);
     }
 
     public static void Assert_JObjectContainsPropertiesExceptionDetailsWithoutProperty(

--- a/Tests/Serilog.Exceptions.Test/Destructurers/ValidationApiExceptionDestructurerTests.cs
+++ b/Tests/Serilog.Exceptions.Test/Destructurers/ValidationApiExceptionDestructurerTests.cs
@@ -1,0 +1,141 @@
+namespace Serilog.Exceptions.Test.Destructurers;
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using global::Refit;
+using Serilog.Exceptions.Core;
+using Serilog.Exceptions.Refit.Destructurers;
+using Xunit;
+using static LogJsonOutputUtils;
+
+public class ValidationApiExceptionDestructurerTests
+{
+    private const string ProblemDetailsJson = "application/problem+json";
+    private readonly ProblemDetails problemDetailsBadRequest;
+
+    public ValidationApiExceptionDestructurerTests() => this.problemDetailsBadRequest = new ProblemDetails
+    {
+        Detail = "A validation failure has occurred",
+        Status = (int)HttpStatusCode.BadRequest,
+        Title = "Bad Request",
+        Type = "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+    };
+
+    [Fact]
+    public async Task ValidationApiException_HttpStatusCodeIsLoggedAsPropertyAsync()
+    {
+        using var message = new HttpRequestMessage(HttpMethod.Get, new Uri("https://foobar.com"));
+        using var response = new HttpResponseMessage(HttpStatusCode.BadRequest);
+        var responseContent = JsonSerializer.Serialize(this.problemDetailsBadRequest);
+        response.Content = new StringContent(responseContent, System.Text.Encoding.UTF8, ProblemDetailsJson);
+        var options = new DestructuringOptionsBuilder().WithDestructurers(new[] { new ValidationApiExceptionDestructurer() });
+        var apiException = await ApiException.Create(message, HttpMethod.Get, response, new RefitSettings()).ConfigureAwait(false);
+        var validationApiException = ValidationApiException.Create(apiException);
+
+        Test_LoggedExceptionContainsProperty(validationApiException, nameof(ValidationApiException.StatusCode), nameof(HttpStatusCode.BadRequest), options);
+    }
+
+    [Fact]
+    public async Task ValidationApiException_UriIsLoggedAsPropertyAsync()
+    {
+        var requestUri = new Uri("https://foobar.com");
+        using var message = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        using var response = new HttpResponseMessage(HttpStatusCode.BadRequest);
+        var responseContent = JsonSerializer.Serialize(this.problemDetailsBadRequest);
+        response.Content = new StringContent(responseContent, System.Text.Encoding.UTF8, ProblemDetailsJson);
+        var options = new DestructuringOptionsBuilder().WithDestructurers(new[] { new ValidationApiExceptionDestructurer() });
+        var apiException = await ApiException.Create(message, HttpMethod.Get, response, new RefitSettings()).ConfigureAwait(false);
+        var validationApiException = ValidationApiException.Create(apiException);
+
+        Test_LoggedExceptionContainsProperty(validationApiException, nameof(ValidationApiException.Uri), requestUri.ToString(), options);
+    }
+
+    [Fact]
+    public async Task ValidationApiException_ByDefaultContentIsNotLoggedAsPropertyAsync()
+    {
+        var requestUri = new Uri("https://foobar.com");
+        using var message = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        using var response = new HttpResponseMessage(HttpStatusCode.BadRequest);
+        var responseContent = JsonSerializer.Serialize(this.problemDetailsBadRequest);
+        response.Content = new StringContent(responseContent, System.Text.Encoding.UTF8, ProblemDetailsJson);
+        var options = new DestructuringOptionsBuilder().WithDestructurers(new[] { new ValidationApiExceptionDestructurer() });
+        var apiException = await ApiException.Create(message, HttpMethod.Get, response, new RefitSettings()).ConfigureAwait(false);
+        var validationApiException = ValidationApiException.Create(apiException);
+
+        Test_LoggedExceptionDoesNotContainProperty(validationApiException, nameof(ValidationApiException.Content), options);
+    }
+
+    [Fact]
+    public async Task ValidationApiException_WhenSpecifiedContentIsLoggedAsPropertyAsync()
+    {
+        var requestUri = new Uri("https://foobar.com");
+        using var message = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        using var response = new HttpResponseMessage(HttpStatusCode.BadRequest);
+        var responseContent = JsonSerializer.Serialize(this.problemDetailsBadRequest);
+        response.Content = new StringContent(responseContent, System.Text.Encoding.UTF8, ProblemDetailsJson);
+        var options = new DestructuringOptionsBuilder().WithDestructurers(new[] { new ValidationApiExceptionDestructurer(destructureHttpContent: true) });
+        var apiException = await ApiException.Create(message, HttpMethod.Get, response, new RefitSettings()).ConfigureAwait(false);
+        var validationApiException = ValidationApiException.Create(apiException);
+
+        Test_LoggedExceptionContainsProperty(
+            validationApiException,
+            nameof(ValidationApiException.Content),
+            nameof(this.problemDetailsBadRequest.Status),
+            this.problemDetailsBadRequest.Status.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            options);
+        Test_LoggedExceptionContainsProperty(
+            validationApiException,
+            nameof(ValidationApiException.Content),
+            nameof(this.problemDetailsBadRequest.Title),
+            this.problemDetailsBadRequest.Title,
+            options);
+        Test_LoggedExceptionContainsProperty(
+            validationApiException,
+            nameof(ValidationApiException.Content),
+            nameof(this.problemDetailsBadRequest.Detail),
+            this.problemDetailsBadRequest.Detail,
+            options);
+    }
+
+    [Fact]
+    public async Task ValidationApiException_ByDefaultCommonPropertiesLoggedAsPropertiesAsync()
+    {
+        var requestUri = new Uri("https://foobar.com");
+        using var message = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        using var response = new HttpResponseMessage(HttpStatusCode.BadRequest);
+        var responseContent = JsonSerializer.Serialize(this.problemDetailsBadRequest);
+        response.Content = new StringContent(responseContent, System.Text.Encoding.UTF8, ProblemDetailsJson);
+        var options = new DestructuringOptionsBuilder().WithDestructurers(new[] { new ValidationApiExceptionDestructurer() });
+        var apiException = await ApiException.Create(message, HttpMethod.Get, response, new RefitSettings()).ConfigureAwait(false);
+        var validationApiException = ValidationApiException.Create(apiException);
+
+        // No need to test all properties, just a handful is sufficient
+        Test_LoggedExceptionContainsProperty(validationApiException, nameof(Exception.StackTrace), validationApiException.StackTrace, options);
+        Test_LoggedExceptionContainsProperty(validationApiException, nameof(Exception.Message), validationApiException.Message, options);
+        Test_LoggedExceptionContainsProperty(validationApiException, nameof(Type), apiException.GetType().ToString(), options);
+    }
+
+    [Fact]
+    public async Task ValidationApiException_WhenSpecifiedCommonPropertiesNotLoggedAsPropertiesAsync()
+    {
+        var requestUri = new Uri("https://foobar.com");
+        using var message = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        using var response = new HttpResponseMessage(HttpStatusCode.BadRequest);
+        var responseContent = JsonSerializer.Serialize(this.problemDetailsBadRequest);
+        response.Content = new StringContent(responseContent, System.Text.Encoding.UTF8, ProblemDetailsJson);
+        var options = new DestructuringOptionsBuilder().WithDestructurers(new[] { new ValidationApiExceptionDestructurer(destructureCommonExceptionProperties: false) });
+        var apiException = await ApiException.Create(message, HttpMethod.Get, response, new RefitSettings()).ConfigureAwait(false);
+        var validationApiException = ValidationApiException.Create(apiException);
+
+        Test_LoggedExceptionDoesNotContainProperty(validationApiException, nameof(Exception.StackTrace), options);
+        Test_LoggedExceptionDoesNotContainProperty(validationApiException, nameof(Exception.Message), options);
+        Test_LoggedExceptionDoesNotContainProperty(validationApiException, nameof(Exception.InnerException), options);
+        Test_LoggedExceptionDoesNotContainProperty(validationApiException, nameof(Exception.HelpLink), options);
+        Test_LoggedExceptionDoesNotContainProperty(validationApiException, nameof(Exception.Data), options);
+        Test_LoggedExceptionDoesNotContainProperty(validationApiException, nameof(Exception.HResult), options);
+        Test_LoggedExceptionDoesNotContainProperty(validationApiException, nameof(Type), options);
+    }
+}


### PR DESCRIPTION
### Background
On a project which I am working on, we noticed that Bearer tokens were being logged to Seq with Refit exceptions, despite the fact that we were using the `ApiExceptionDestructurer`. On a closer inspection, we discovered that it was a `ValidationApiException` which Refit was throwing and this was not covered by the `ApiExceptionDestructurer`.

After discussing whether to change the `ApiExceptionDestructurer` or create a new destructurer, we settled on that, making it easy to mix and match the destructurers to suit an API's needs. 

To that end, I'm submitting this PR to add the `ValidationApiExceptionDestructurer` to handle ValidationApiExceptions thrown by Refit.