### PR TITLE
Add ValidationApiException support for Refit

### DIFF
--- a/Source/Serilog.Exceptions.Refit/Destructurers/ApiExceptionDestructurer.cs
+++ b/Source/Serilog.Exceptions.Refit/Destructurers/ApiExceptionDestructurer.cs
@@ -27,7 +27,7 @@ public class ApiExceptionDestructurer : ExceptionDestructurer
     }
 
     /// <inheritdoc cref="IExceptionDestructurer.TargetTypes"/>
-    public override Type[] TargetTypes => new[] { typeof(ApiException) };
+    public override Type[] TargetTypes => new[] { typeof(ApiException), typeof(ValidationApiException) };
 
     /// <inheritdoc />
     public override void Destructure(Exception exception, IExceptionPropertiesBag propertiesBag, Func<Exception, IReadOnlyDictionary<string, object?>?> destructureException)


### PR DESCRIPTION
As title suggests. Currently if a `ValidationApiException` is raised, the Refit destructerer won't pick it up.