### PR TITLE
update to Grpc.Core.Api 2.66.0

### DIFF
--- a/Source/Serilog.Exceptions.Grpc/Serilog.Exceptions.Grpc.csproj
+++ b/Source/Serilog.Exceptions.Grpc/Serilog.Exceptions.Grpc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.5;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Grpc.Core.Api" Version="2.47.0" />
+    <PackageReference Include="Grpc.Core.Api" Version="2.66.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
and drop netstandard1.5 support from Serilog.Exceptions.Grpc
